### PR TITLE
remove requestauthentication resource

### DIFF
--- a/kubeflow/helm/pipelines/Chart.yaml
+++ b/kubeflow/helm/pipelines/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: pipelines
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.84
+version: 0.1.85
 appVersion: "1.7.1"

--- a/kubeflow/helm/pipelines/templates/api-server/requestauthentication.yaml
+++ b/kubeflow/helm/pipelines/templates/api-server/requestauthentication.yaml
@@ -1,9 +1,0 @@
-apiVersion: security.istio.io/v1beta1
-kind: RequestAuthentication
-metadata:
-  name: kubeflow-request-auth
-  namespace: kubeflow
-spec:
-  jwtRules:
-  - issuer: https://oidc.plural.sh/
-    jwksUri: https://oidc.plural.sh/.well-known/jwks.json


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you with us! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->

The RequestAuthentication reosource in the kubeflow namespace is obsolete. It caused IRSA to modify the jwt issuer, leading to the observed exceptions.

This PR is related to issue #146 .

I tested the change by accessing kubeflow pipelines as described in the linked issue.


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.