### PR TITLE
set k8s version explicitly in bootstrap

### DIFF
--- a/bootstrap/terraform/aws-bootstrap/main.tf
+++ b/bootstrap/terraform/aws-bootstrap/main.tf
@@ -35,7 +35,7 @@ module "vpc" {
 module "cluster" {
   source          = "github.com/pluralsh/terraform-aws-eks?ref=always-create-auth-cm"
   cluster_name    = var.cluster_name
-  cluster_version = "1.21"
+  cluster_version = var.k8s_version
   private_subnets = module.vpc.private_subnets_ids
   public_subnets  = module.vpc.public_subnets_ids
   worker_private_subnets = module.vpc.worker_private_subnets

--- a/bootstrap/terraform/aws-bootstrap/variables.tf
+++ b/bootstrap/terraform/aws-bootstrap/variables.tf
@@ -1,3 +1,8 @@
+variable "k8s_version" {
+  type = string
+  default = "1.21"
+}
+
 variable "vpc_name" {
   type = string
   default = "forge"

--- a/bootstrap/terraform/azure-bootstrap/main.tf
+++ b/bootstrap/terraform/azure-bootstrap/main.tf
@@ -13,7 +13,7 @@ module "network" {
 module "aks" {
   source                           = "github.com/pluralsh/terraform-azurerm-aks?ref=plural"
   resource_group_name              = data.azurerm_resource_group.group.name
-  kubernetes_version               = "1.21.2"
+  kubernetes_version               = var.k8s_version
   orchestrator_version             = "1.21.2"
   prefix                           = var.name
   cluster_name                     = var.name

--- a/bootstrap/terraform/azure-bootstrap/variables.tf
+++ b/bootstrap/terraform/azure-bootstrap/variables.tf
@@ -1,3 +1,8 @@
+variable "k8s_version" {
+  type = string
+  default = "1.21.2"
+}
+
 variable "subnet_name" {
   type = string
   default = "plural-subnet"

--- a/bootstrap/terraform/gcp-bootstrap/main.tf
+++ b/bootstrap/terraform/gcp-bootstrap/main.tf
@@ -31,6 +31,7 @@ module "gke" {
   source                     = "github.com/pluralsh/terraform-google-kubernetes-engine?ref=rm-k8s-provider"
   project_id                 = var.gcp_project_id
   name                       = var.cluster_name
+  kubernetes_version         = var.k8s_version
   region                     = local.gcp_region
   network                    = google_compute_network.vpc_network.name
   subnetwork                 = google_compute_subnetwork.vpc_subnetwork.name

--- a/bootstrap/terraform/gcp-bootstrap/variables.tf
+++ b/bootstrap/terraform/gcp-bootstrap/variables.tf
@@ -1,3 +1,8 @@
+variable "k8s_version" {
+  type = string
+  default = "1.21.2"
+}
+
 variable "gcp_project_id" {
   type = string
 


### PR DESCRIPTION
## Summary
This makes it so the k8s version across our cloud providers is explicitly defined.
closes #165 


## Test Plan

## Checklist
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.