### PR TITLE
GKE: Pin K8s version, use cilium, setup similar node group to EKS

### DIFF
--- a/bootstrap/terraform/gcp-bootstrap/deps.yaml
+++ b/bootstrap/terraform/gcp-bootstrap/deps.yaml
@@ -2,7 +2,7 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: Creates a GKE cluster and adds initial configuration
-  version: 0.1.4
+  version: 0.2.0
 spec:
   breaking: true
   dependencies: []

--- a/bootstrap/terraform/gcp-bootstrap/deps.yaml
+++ b/bootstrap/terraform/gcp-bootstrap/deps.yaml
@@ -4,6 +4,7 @@ metadata:
   description: Creates a GKE cluster and adds initial configuration
   version: 0.1.4
 spec:
+  breaking: true
   dependencies: []
   providers:
   - gcp

--- a/bootstrap/terraform/gcp-bootstrap/main.tf
+++ b/bootstrap/terraform/gcp-bootstrap/main.tf
@@ -47,8 +47,8 @@ module "gke" {
   http_load_balancing        = true
   remove_default_node_pool   = true
   add_cluster_firewall_rules = true
-  network_policy             = false
-  datapath_provider          = "ADVANCED_DATAPATH"
+  network_policy             = var.network_policy_enabled
+  datapath_provider          = var.datapath_provider
   kubernetes_version         = var.k8s_version
   filestore_csi_driver       = true
 

--- a/bootstrap/terraform/gcp-bootstrap/main.tf
+++ b/bootstrap/terraform/gcp-bootstrap/main.tf
@@ -47,7 +47,9 @@ module "gke" {
   http_load_balancing        = true
   remove_default_node_pool   = true
   add_cluster_firewall_rules = true
-  network_policy             = true
+  network_policy             = false
+  datapath_provider          = "ADVANCED_DATAPATH"
+  kubernetes_version         = "1.22.6-gke.300"
   filestore_csi_driver       = true
 
   node_pools = var.node_pools

--- a/bootstrap/terraform/gcp-bootstrap/main.tf
+++ b/bootstrap/terraform/gcp-bootstrap/main.tf
@@ -49,10 +49,14 @@ module "gke" {
   add_cluster_firewall_rules = true
   network_policy             = false
   datapath_provider          = "ADVANCED_DATAPATH"
-  kubernetes_version         = "1.22.6-gke.300"
+  kubernetes_version         = var.k8s_version
   filestore_csi_driver       = true
 
   node_pools = var.node_pools
+
+  node_pools_labels = var.node_pools_labels
+
+  node_pools_taints = var.node_pools_taints
 
   depends_on = [google_compute_subnetwork.vpc_subnetwork]
 }

--- a/bootstrap/terraform/gcp-bootstrap/main.tf
+++ b/bootstrap/terraform/gcp-bootstrap/main.tf
@@ -49,7 +49,7 @@ module "gke" {
   add_cluster_firewall_rules = true
   network_policy             = var.network_policy_enabled
   datapath_provider          = var.datapath_provider
-  kubernetes_version         = var.k8s_version
+  kubernetes_version         = var.kubernetes_version
   filestore_csi_driver       = true
 
   node_pools = var.node_pools

--- a/bootstrap/terraform/gcp-bootstrap/terraform.tfvars
+++ b/bootstrap/terraform/gcp-bootstrap/terraform.tfvars
@@ -6,7 +6,11 @@ externaldns_sa_name = "{{ .Cluster }}-externaldns"
 gcp_region = {{ .Region | quote }}
 {{- if $bootstrapOutputs }}
 network_policy_enabled = {{ $bootstrapOutputs.cluster.network_policy_enabled }}
+{{- if eq $bootstrapOutputs.cluster.datapath_provider "" }}
+datapath_provider = "DATAPATH_PROVIDER_UNSPECIFIED"
+{{- else }}
 datapath_provider = {{ $bootstrapOutputs.cluster.datapath_provider | quote }}
+{{- end }}
 {{- else }}
 network_policy_enabled = false
 datapath_provider = "ADVANCED_DATAPATH"

--- a/bootstrap/terraform/gcp-bootstrap/terraform.tfvars
+++ b/bootstrap/terraform/gcp-bootstrap/terraform.tfvars
@@ -1,5 +1,13 @@
+{{- $bootstrapOutputs := .Applications.TerraformValues "bootstrap" }}
 gcp_project_id = {{ .Project | quote }}
 cluster_name = {{ .Cluster | quote }}
 vpc_name_prefix = {{ .Values.vpc_name | quote }}
 externaldns_sa_name = "{{ .Cluster }}-externaldns"
 gcp_region = {{ .Region | quote }}
+{{- if $bootstrapOutputs }}
+network_policy_enabled = {{ $bootstrapOutputs.cluster.network_policy_enabled }}
+datapath_provider = {{ $bootstrapOutputs.cluster.datapath_provider | quote }}
+{{- else }}
+network_policy_enabled = false
+datapath_provider = "ADVANCED_DATAPATH"
+{{- end }}

--- a/bootstrap/terraform/gcp-bootstrap/variables.tf
+++ b/bootstrap/terraform/gcp-bootstrap/variables.tf
@@ -47,39 +47,167 @@ variable "node_pools" {
   type = list
   default = [
     {
-      name               = "default-node-pool"
-      machine_type       = "n2d-standard-2"
+      name               = "small-burst-on-demand"
+      machine_type       = "e2-standard-2"
       min_count          = 1
-      max_count          = 5
-      disk_size_gb       = 100
+      max_count          = 9
+      disk_size_gb       = 50
       disk_type          = "pd-standard"
       image_type         = "COS_CONTAINERD"
+      spot               = false
       auto_repair        = true
       auto_upgrade       = true
       preemptible        = false
       initial_node_count = 1
       autoscaling        = true
     },
+    # {
+    #   name               = "small-burst-spot"
+    #   machine_type       = "e2-standard-2"
+    #   min_count          = 0
+    #   max_count          = 9
+    #   disk_size_gb       = 50
+    #   disk_type          = "pd-standard"
+    #   image_type         = "COS_CONTAINERD"
+    #   spot               = true
+    #   auto_repair        = true
+    #   auto_upgrade       = true
+    #   preemptible        = false
+    #   initial_node_count = 0
+    #   autoscaling        = true
+    # },
     {
-      name               = "default-node-pool-spot"
-      machine_type       = "n2d-standard-2"
+      name               = "medium-burst-on-demand"
+      machine_type       = "e2-standard-4"
       min_count          = 0
-      max_count          = 5
-      disk_size_gb       = 100
+      max_count          = 9
+      disk_size_gb       = 50
       disk_type          = "pd-standard"
       image_type         = "COS_CONTAINERD"
-      spot               = true
+      spot               = false
       auto_repair        = true
       auto_upgrade       = true
       preemptible        = false
-      initial_node_count = 1
+      initial_node_count = 0
       autoscaling        = true
     },
+    # {
+    #   name               = "medium-burst-spot"
+    #   machine_type       = "e2-standard-4"
+    #   min_count          = 0
+    #   max_count          = 9
+    #   disk_size_gb       = 50
+    #   disk_type          = "pd-standard"
+    #   image_type         = "COS_CONTAINERD"
+    #   spot               = true
+    #   auto_repair        = true
+    #   auto_upgrade       = true
+    #   preemptible        = false
+    #   initial_node_count = 0
+    #   autoscaling        = true
+    # },
+
+    {
+      name               = "large-burst-on-demand"
+      machine_type       = "e2-standard-8"
+      min_count          = 0
+      max_count          = 9
+      disk_size_gb       = 50
+      disk_type          = "pd-standard"
+      image_type         = "COS_CONTAINERD"
+      spot               = false
+      auto_repair        = true
+      auto_upgrade       = true
+      preemptible        = false
+      initial_node_count = 0
+      autoscaling        = true
+    },
+    # {
+    #   name               = "large-burst-spot"
+    #   machine_type       = "e2-standard-8"
+    #   min_count          = 0
+    #   max_count          = 9
+    #   disk_size_gb       = 50
+    #   disk_type          = "pd-standard"
+    #   image_type         = "COS_CONTAINERD"
+    #   spot               = true
+    #   auto_repair        = true
+    #   auto_upgrade       = true
+    #   preemptible        = false
+    #   initial_node_count = 0
+    #   autoscaling        = true
+    # },
   ]
 
   description = <<EOF
   The node pools for your cluster
 EOF
+}
+
+variable "node_pools_labels" {
+  type = map(map(string))
+  default = {
+
+    all = {}
+    "small-burst-on-demand" = {
+      "plural.sh/capacityType" = "ON_DEMAND"
+      "plural.sh/performanceType" = "BURST"
+      "plural.sh/scalingGroup" = "small-burst-on-demand"
+    }
+    # "small-burst-spot" = {
+    #   "plural.sh/capacityType" = "SPOT"
+    #   "plural.sh/performanceType" = "BURST"
+    #   "plural.sh/scalingGroup" = "small-burst-spot"
+    # }
+    medium-burst-on-demand = {
+      "plural.sh/capacityType" = "ON_DEMAND"
+      "plural.sh/performanceType" = "BURST"
+      "plural.sh/scalingGroup" = "medium-burst-on-demand"
+    }
+    # medium-burst-spot = {
+    #   "plural.sh/capacityType" = "SPOT"
+    #   "plural.sh/performanceType" = "BURST"
+    #   "plural.sh/scalingGroup" = "medium-burst-spot"
+    # }
+    large-burst-on-demand = {
+      "plural.sh/capacityType" = "ON_DEMAND"
+      "plural.sh/performanceType" = "BURST"
+      "plural.sh/scalingGroup" = "large-burst-on-demand"
+    }
+    # large-burst-spot = {
+    #   "plural.sh/capacityType" = "SPOT"
+    #   "plural.sh/performanceType" = "BURST"
+    #   "plural.sh/scalingGroup" = "large-burst-spot"
+    # }
+  }
+}
+
+variable "node_pools_taints" {
+  type = map(list(object({ key = string, value = string, effect = string })))
+  default = {
+    all = [],
+    # small-burst-spot = [
+    #   {
+    #     key    = "plural.sh/capacityType"
+    #     value  = "SPOT"
+    #     effect = "NO_SCHEDULE"
+    #   },
+    # ],
+    # meium-burst-spot = [
+    #   {
+    #     key    = "plural.sh/capacityType"
+    #     value  = "SPOT"
+    #     effect = "NO_SCHEDULE"
+    #   },
+    # ],
+    # large-burst-spot = [
+    #   {
+    #     key    = "plural.sh/capacityType"
+    #     value  = "SPOT"
+    #     effect = "NO_SCHEDULE"
+    #   },
+    # ]
+  }
 }
 
 variable "vpc_network_name" {
@@ -109,6 +237,11 @@ variable "vpc_subnetwork_name" {
 The name of the Google Compute Engine subnetwork in which the cluster's
 instances are launched.
 EOF
+}
+
+variable "k8s_version" {
+  type = string
+  default = "1.22.6-gke.300"
 }
 
 variable "vpc_subnetwork_cidr_range" {

--- a/bootstrap/terraform/gcp-bootstrap/variables.tf
+++ b/bootstrap/terraform/gcp-bootstrap/variables.tf
@@ -241,7 +241,7 @@ EOF
 
 variable "kubernetes_version" {
   type = string
-  default = "1.22.7-gke.1300"
+  default = "1.22.7-gke.1500"
 }
 
 variable "vpc_subnetwork_cidr_range" {

--- a/bootstrap/terraform/gcp-bootstrap/variables.tf
+++ b/bootstrap/terraform/gcp-bootstrap/variables.tf
@@ -241,7 +241,7 @@ EOF
 
 variable "k8s_version" {
   type = string
-  default = "1.22.7-gke.900"
+  default = "1.22.7-gke.1300"
 }
 
 variable "vpc_subnetwork_cidr_range" {

--- a/bootstrap/terraform/gcp-bootstrap/variables.tf
+++ b/bootstrap/terraform/gcp-bootstrap/variables.tf
@@ -306,3 +306,15 @@ variable "firewall_inbound_ports" {
   description = "List of TCP ports for admission/webhook controllers"
   default     = ["8443", "9443", "15017"]
 }
+
+variable "network_policy_enabled" {
+  type = bool
+  default = false
+  description = "Enable network policy addon. Cannot be used with ADVANCED_DATAPATH."
+}
+
+variable "datapath_provider" {
+  type        = string
+  description = "The desired datapath provider for this cluster. By default, `DATAPATH_PROVIDER_UNSPECIFIED` enables the IPTables-based kube-proxy implementation. `ADVANCED_DATAPATH` enables Dataplane-V2 feature."
+  default     = "ADVANCED_DATAPATH"
+}

--- a/bootstrap/terraform/gcp-bootstrap/variables.tf
+++ b/bootstrap/terraform/gcp-bootstrap/variables.tf
@@ -48,12 +48,27 @@ variable "node_pools" {
   default = [
     {
       name               = "default-node-pool"
-      machine_type       = "n1-standard-2"
+      machine_type       = "n2d-standard-2"
       min_count          = 1
       max_count          = 5
       disk_size_gb       = 100
       disk_type          = "pd-standard"
-      image_type         = "COS"
+      image_type         = "COS_CONTAINERD"
+      auto_repair        = true
+      auto_upgrade       = true
+      preemptible        = false
+      initial_node_count = 1
+      autoscaling        = true
+    },
+    {
+      name               = "default-node-pool-spot"
+      machine_type       = "n2d-standard-2"
+      min_count          = 0
+      max_count          = 5
+      disk_size_gb       = 100
+      disk_type          = "pd-standard"
+      image_type         = "COS_CONTAINERD"
+      spot               = true
       auto_repair        = true
       auto_upgrade       = true
       preemptible        = false

--- a/bootstrap/terraform/gcp-bootstrap/variables.tf
+++ b/bootstrap/terraform/gcp-bootstrap/variables.tf
@@ -239,7 +239,7 @@ instances are launched.
 EOF
 }
 
-variable "k8s_version" {
+variable "kubernetes_version" {
   type = string
   default = "1.22.7-gke.1300"
 }

--- a/bootstrap/terraform/gcp-bootstrap/variables.tf
+++ b/bootstrap/terraform/gcp-bootstrap/variables.tf
@@ -241,7 +241,7 @@ EOF
 
 variable "k8s_version" {
   type = string
-  default = "1.22.6-gke.300"
+  default = "1.22.7-gke.900"
 }
 
 variable "vpc_subnetwork_cidr_range" {


### PR DESCRIPTION
Requires: https://github.com/pluralsh/plural/pull/178

## Summary
Pins the GKE kubernetes version. Uses Cilium as the CNI. Sets up the same type of node groups as we use on EKS with the same labels. Also deploys the FileStore CSI driver.


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.