### PR TITLE
update gke module and set tf outputs + enable filestore CSI

### DIFF
--- a/bootstrap/terraform/gcp-bootstrap/deps.yaml
+++ b/bootstrap/terraform/gcp-bootstrap/deps.yaml
@@ -2,10 +2,13 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: Creates a GKE cluster and adds initial configuration
-  version: 0.1.3
+  version: 0.1.4
 spec:
   dependencies: []
   providers:
   - gcp
+  outputs:
+    cluster: cluster
+    vpc_network: vpc_network
   provider_wirings:
     cluster: module.gcp-bootstrap.cluster

--- a/bootstrap/terraform/gcp-bootstrap/main.tf
+++ b/bootstrap/terraform/gcp-bootstrap/main.tf
@@ -28,7 +28,7 @@ resource "google_compute_subnetwork" "vpc_subnetwork" {
 }
 
 module "gke" {
-  source                     = "github.com/pluralsh/terraform-google-kubernetes-engine?ref=rm-k8s-provider"
+  source                     = "github.com/pluralsh/terraform-google-kubernetes-engine?ref=filestore-csi-driver"
   project_id                 = var.gcp_project_id
   name                       = var.cluster_name
   region                     = local.gcp_region
@@ -41,6 +41,7 @@ module "gke" {
   remove_default_node_pool   = true
   add_cluster_firewall_rules = true
   network_policy             = true
+  filestore_csi_driver       = true
 
   node_pools = var.node_pools
 


### PR DESCRIPTION
## Summary
This PR depends on https://github.com/pluralsh/plural/pull/178. It updates the upstream GKE module, enables the filestore CSI driver and adds the TF outputs to the `deps.yaml` so Plural can process them properly.
