### PR TITLE
Remove registry when pushing vendored image

### DIFF
--- a/.github/actions/vendor/index.js
+++ b/.github/actions/vendor/index.js
@@ -3,18 +3,24 @@ const exec = require('@actions/exec');
 
 async function run() {
   const img = core.getInput('img');
+  const imgArray = img.split("/");
+  if (imgArray[0].includes(".")) {
+    imgOut = img.replace(imgArray[0]+'/', '')
+  } else {
+    imgOut = img
+  }
   const repo = core.getInput('repo');
   await exec.exec(`docker pull ${img}`)
-  await tagAndPush(img, 'gcr.io/pluralsh/')
+  await tagAndPush(img, imgOut, 'gcr.io/pluralsh/')
 
   if (repo) {
-    await tagAndPush(img, `dkr.plural.sh/${repo}/`)
+    await tagAndPush(img, imgOut, `dkr.plural.sh/${repo}/`)
   }
 }
 
-async function tagAndPush(img, prefix) {
-  await exec.exec(`docker tag ${img} ${prefix}${img}`)
-  await exec.exec(`docker push ${prefix}${img}`)
+async function tagAndPush(img, imgOut, prefix) {
+  await exec.exec(`docker tag ${img} ${prefix}${imgOut}`)
+  await exec.exec(`docker push ${prefix}${imgOut}`)
 }
 
 run();


### PR DESCRIPTION
## Summary
This PR makes a change to the vendoring action so that it remove registry prefixes while tagging and pushing to our registries.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.