### PR TITLE
Fix airflow azure logs

### DIFF
--- a/airflow/helm/airflow/Chart.yaml
+++ b/airflow/helm/airflow/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: airflow
 description: A Helm chart for airflow deployable on plural
 type: application
-version: 0.3.16
+version: 0.3.17
 appVersion: "1.16.0"
 sources:
 - https://github.com/pluralsh/plural-artifacts/airflow/helm/airflow

--- a/airflow/helm/airflow/values.yaml.tpl
+++ b/airflow/helm/airflow/values.yaml.tpl
@@ -135,7 +135,7 @@ airflow:
         {
           "aws_access_key_id": {{ importValue "Terraform" "access_key_id" }},
           "aws_secret_access_key": {{ importValue "Terraform" "secret_access_key" }},
-          "host": "{{ .Configuration.minio.hostname }}"
+          "host": "https://{{ .Configuration.minio.hostname }}"
         }
     {{ end }}
     {{ if eq .Provider "kind" }}


### PR DESCRIPTION
## Summary
We needed to prefix the minio endpoint with https://.  Otherwise credentials are all properly placed and seems to function.

## Test Plan
`plural link helm airflow --name airflow --path ../plural-az-installations/airflow/helm/airflow` and kicked off a dag run to check its logs

## Checklist
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.