### PR TITLE
Update cert-manager fork to increase clusterissuer timeout

### DIFF
--- a/bootstrap/helm/bootstrap/Chart.yaml
+++ b/bootstrap/helm/bootstrap/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 maintainers:
 - name: michaeljguarino
   email: mguarino46@gmail.com
-version: 0.8.41
+version: 0.8.42
 dependencies:
 - name: external-dns
   version: 4.11.0

--- a/bootstrap/helm/bootstrap/templates/cm-shim.yaml
+++ b/bootstrap/helm/bootstrap/templates/cm-shim.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cert-manager-shim
+  labels:
+  {{ include "bootstrap.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-shim-binding
+  labels:
+  {{ include "bootstrap.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-shim
+subjects:
+- kind: ServiceAccount
+  name: certmanager
+  namespace: {{ .Release.Namespace }}

--- a/bootstrap/helm/bootstrap/values.yaml
+++ b/bootstrap/helm/bootstrap/values.yaml
@@ -161,7 +161,7 @@ tigera-operator:
 cert-manager:
   image:
     repository: gcr.io/pluralsh/cert-manager/cert-manager-controller
-    tag: v1.7.0-alpha
+    tag: v1.7.0-alpha.0.572-462eca887c2a98
   serviceAccount:
     name: certmanager
   prometheus:


### PR DESCRIPTION
## Summary

This issue is making some users wait unusually long amounts of time for cert issuance, and is a plausible solve.  Lets see if it works.


## Test Plan
plural link to our azure deployment, destroyed and redeployed airflow, confirmed certs were reissued promptly.

## Checklist
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.