### PR TITLE
add hasura admin secret to notes.tpl

### DIFF
--- a/hasura/plural/notes.tpl
+++ b/hasura/plural/notes.tpl
@@ -1,1 +1,3 @@
 you can view your hasura installation at https://{{ .Values.hostname }}
+
+Your hasura admin secret is: {{ .hasura.hasura.adminSecret }}


### PR DESCRIPTION
## Summary
We don't currently print the hasura admin secrets in the deployment notes, so users have to manually fetch it.

## Test Plan
can't test locally unfortunately

## Checklist
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.