### PR TITLE
Extend superset image with appropriate python packages

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -111,3 +111,30 @@ jobs:
         docker push gcr.io/pluralsh/apache/airflow:2.1.4-python3.8
         docker push dkr.plural.sh/airflow/apache/airflow:2.1.4-python3.8
   
+  docker-superset:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+    - uses: actions/checkout@v2
+    - uses: google-github-actions/auth@v0
+      with:
+        workload_identity_provider: 'projects/${{ secrets.GOOGLE_PROJECT_ID }}/locations/global/workloadIdentityPools/github/providers/github'
+        service_account: 'terraform@pluralsh.iam.gserviceaccount.com'
+        token_format: 'access_token'
+        create_credentials_file: true
+    - uses: google-github-actions/setup-gcloud@v0.3.0
+    - name: Login to gcr
+      run: gcloud auth configure-docker -q
+    - name: Login to plural registry
+      uses: docker/login-action@v1
+      with:
+        registry: dkr.plural.sh
+        username: mjg@plural.sh
+        password: ${{ secrets.PLURAL_ACCESS_TOKEN }}
+    - run: |
+        docker build -f superset/Dockerfile -t gcr.io/pluralsh/apache/superset:1.3.2 -t dkr.plural.sh/superset/apache/superset:1.3.2 .
+        docker push gcr.io/pluralsh/apache/superset:1.3.2
+        docker push dkr.plural.sh/superset/apache/superset:1.3.2
+  

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -1,0 +1,8 @@
+FROM gcr.io/pluralsh/apache/superset:3c41ff68a43b5ab6b871226a73de9f2129d64766
+
+RUN pip install \
+      psycopg2==2.8.5 \
+      Authlib~=0.15.3 \
+      pyjwt \
+      pybigquery \
+      redis==3.2.1

--- a/superset/helm/superset/values.yaml
+++ b/superset/helm/superset/values.yaml
@@ -107,11 +107,6 @@ superset:
   bootstrapScript: |
     #!/bin/bash
     rm -rf /var/lib/apt/lists/* && \
-    pip install \
-      psycopg2==2.8.5 \
-      Authlib~=0.15.3 \
-      pyjwt \
-      redis==3.2.1 && \
     if [ ! -f ~/bootstrap ]; then echo "Running Superset with uid {{ .Values.runAsUser }}" > ~/bootstrap; fi
   postgresql:
     enabled: false


### PR DESCRIPTION
## Summary

Currently superset doesn't have the bq driver installed, and it's installing some pip packages at build time, which is suboptimal.  This vendors our own ready-to-go image


## Test Plan
Will wire into superset chart as follow-up change

## Checklist
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.