### PR TITLE
Enable gcp apis needed for deployment in terraform

### DIFF
--- a/bootstrap/terraform/gcp-bootstrap/deps.yaml
+++ b/bootstrap/terraform/gcp-bootstrap/deps.yaml
@@ -2,7 +2,7 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: Creates a GKE cluster and adds initial configuration
-  version: 0.2.3
+  version: 0.2.4
 spec:
   dependencies: []
   providers:

--- a/bootstrap/terraform/gcp-bootstrap/main.tf
+++ b/bootstrap/terraform/gcp-bootstrap/main.tf
@@ -3,6 +3,56 @@ resource "google_compute_network" "vpc_network" {
   auto_create_subnetworks = "false"
 }
 
+resource "google_project_service" "gcr" {
+  project = var.gcp_project_id
+  service = "artifactregistry.googleapis.com"
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_project_service" "container" {
+  project = var.gcp_project_id
+  service = "container.googleapis.com"
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_project_service" "iam" {
+  project = var.gcp_project_id
+  service = "iam.googleapis.com"
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_project_service" "storage" {
+  project = var.gcp_project_id
+  service = "storage.googleapis.com"
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_project_service" "dns" {
+  project = var.gcp_project_id
+  service = "dns.googleapis.com"
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
 resource "google_compute_subnetwork" "vpc_subnetwork" {
   name = local.vpc_subnetwork_name
 
@@ -58,7 +108,14 @@ module "gke" {
 
   node_pools_taints = var.node_pools_taints
 
-  depends_on = [google_compute_subnetwork.vpc_subnetwork]
+  depends_on = [
+    google_compute_subnetwork.vpc_subnetwork,
+    google_project_service.gcr,
+    google_project_service.container,
+    google_project_service.iam,
+    google_project_service.storage,
+    google_project_service.dns,
+  ]
 }
 
 resource "kubernetes_namespace" "bootstrap" {


### PR DESCRIPTION
## Summary
We currently require people to manually enable gcp apis, which isn't strictly necessary.  This is a first pass on the apis you'll actually need to get going.

## Test Plan
tested via local link in our cluster

## Checklist
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.

Close #190 