### PR TITLE
Fix Airflow service monitor for external Postgres

### DIFF
--- a/airflow/helm/airflow/Chart.yaml
+++ b/airflow/helm/airflow/Chart.yaml
@@ -2,21 +2,21 @@ apiVersion: v2
 name: airflow
 description: A Helm chart for airflow deployable on plural
 type: application
-version: 0.3.18
+version: 0.3.19
 appVersion: "1.16.0"
 sources:
-- https://github.com/pluralsh/plural-artifacts/airflow/helm/airflow
+  - https://github.com/pluralsh/plural-artifacts/airflow/helm/airflow
 maintainers:
-- name: michaeljguarino
-  email: mjg@plural.sh
+  - name: michaeljguarino
+    email: mjg@plural.sh
 dependencies:
-- name: config-overlays
-  version: 0.1.1
-  repository: https://pluralsh.github.io/module-library
-- name: airflow
-  version: 8.5.2
-  repository: https://airflow-helm.github.io/charts
-- name: test-base
-  repository: https://pluralsh.github.io/module-library
-  version: 0.1.3
-  condition: test-base.enabled
+  - name: config-overlays
+    version: 0.1.1
+    repository: https://pluralsh.github.io/module-library
+  - name: airflow
+    version: 8.5.2
+    repository: https://airflow-helm.github.io/charts
+  - name: test-base
+    repository: https://pluralsh.github.io/module-library
+    version: 0.1.3
+    condition: test-base.enabled

--- a/airflow/helm/airflow/templates/monitors.yaml
+++ b/airflow/helm/airflow/templates/monitors.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.postgres.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -17,4 +16,3 @@ spec:
   selector:
     matchLabels:
       {{- include "statsd-exporter.selectorLabels" . | nindent 6 }}
-{{- end }}


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you with us! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->

I removed the condition based on Postgres for statsd service monitor. This was a mistake I initially introduced. As a result when Postgres is disabled statsd related metrics disappear.


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Tested locally using plural link.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.