### PR TITLE
Grafana 8.3.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.orig
+.*.swp
+.DS_Store
+/.idea/

--- a/grafana/helm/grafana/values.yaml
+++ b/grafana/helm/grafana/values.yaml
@@ -14,7 +14,7 @@ grafana:
 
   image:
     repository: gcr.io/pluralsh/grafana/grafana
-    tag: 8.3.1
+    tag: 8.3.2
   initChownData:
     image:
       repository: gcr.io/pluralsh/busybox


### PR DESCRIPTION
## Consistent Grafana versions 
There was a mismatch between the values.yaml file in grafana helm (plural artifacts https://github.com/pluralsh/plural-artifacts/blob/main/grafana/helm/grafana/values.yaml) and the chart file (https://github.com/pluralsh/plural-artifacts/blob/main/grafana/helm/grafana/Chart.yaml) for the app version → 8.3.1 vs 8.3.2. 

