### PR TITLE
Vault: fix vault policy + jobs + set owner to admin

### DIFF
--- a/vault/helm/vault/Chart.yaml
+++ b/vault/helm/vault/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vault
 description: A Helm chart for Hashicorp Vault on Plural
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: 1.11.0
 dependencies:
 - name: vault

--- a/vault/helm/vault/templates/init-job.yaml
+++ b/vault/helm/vault/templates/init-job.yaml
@@ -73,7 +73,7 @@ data:
     kubectl exec -n {{ .Release.Namespace }} -i vault-0 -c vault -- vault login -no-print -non-interactive "$root_token"
 
     echo "Writing admin policy"
-    kubectl exec -n {{ .Release.Namespace }} -i vault-0 -c vault -- vault policy write admin /policies/admin-policy.hcl
+    kubectl exec -n {{ .Release.Namespace }} -i vault-0 -c vault -- sh /vault/scripts/write-admin-policy.sh
 
     echo "Enabling Kubernetes auth"
     kubectl exec -n {{ .Release.Namespace }} -i vault-0 -c vault -- vault auth enable kubernetes

--- a/vault/helm/vault/templates/oidc-job.yaml
+++ b/vault/helm/vault/templates/oidc-job.yaml
@@ -15,6 +15,9 @@ data:
     echo "Runing script to login in to Vault"
     kubectl exec -n {{ .Release.Namespace }} -i vault-0 -c vault -- sh /vault/scripts/login.sh
 
+    echo "Ensuring admin policy is up to date"
+    kubectl exec -n {{ .Release.Namespace }} -i vault-0 -c vault -- sh /vault/scripts/write-admin-policy.sh
+
     echo "Running script to enable OIDC"
     kubectl exec -n {{ .Release.Namespace }} -i vault-0 -c vault -- sh /vault/scripts/enable-oidc.sh
 ---

--- a/vault/helm/vault/templates/vault-configmap.yaml
+++ b/vault/helm/vault/templates/vault-configmap.yaml
@@ -6,38 +6,71 @@ metadata:
   {{ include "vault-plural.labels" . | nindent 4 }}
 data:
   admin-policy.hcl: |
-    # Allow everything
-    path "*" {
+    # Read system health check
+    path "sys/health"
+    {
+      capabilities = ["read", "sudo"]
+    }
+
+    # Create and manage identities.
+    path "identity/*"
+    {
       capabilities = ["create", "read", "update", "delete", "list", "sudo"]
     }
 
-    # Overwrite `default` policy
-    # ==========================
+    # Create and manage ACL policies broadly across Vault
 
-    # NB: This is necessary because the rule above (path "*") is "weaker" than
-    #     more explicit paths and thus get overriden, typically by the
-    #     `default` policy, which is usually attached as well.
-
-    # NB: The `default` policy can been seen thus:
-    #
-    #     ```sh
-    #     $ vault read sys/policy/default
-    #     ```
-
-    # Allow all actions on the current entity
-    #
-    # NB: The curly brackets contraption is to tell Helm to output a double
-    # curly brackets, which is what Vault also uses for its templated policies.
-    # We also make sure Helm does not insert a newline after, or that will
-    # corrupt the Vault template.
-    path "identity/entity/id/{{ "{{" }}- identity.entity.id }}" {
-      capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+    # List existing policies
+    path "sys/policies/acl"
+    {
+      capabilities = ["list"]
     }
-    path "identity/entity/name/{{ "{{" }}- identity.entity.name }}" {
+
+    # Create and manage ACL policies
+    path "sys/policies/acl/*"
+    {
       capabilities = ["create", "read", "update", "delete", "list", "sudo"]
     }
 
-    # The other rules in the `default` policy should be fine
+    # Enable and manage authentication methods broadly across Vault
+
+    # Manage auth methods broadly across Vault
+    path "auth/*"
+    {
+      capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+    }
+
+    # Create, update, and delete auth methods
+    path "sys/auth/*"
+    {
+      capabilities = ["create", "update", "delete", "sudo"]
+    }
+
+    # List auth methods
+    path "sys/auth"
+    {
+      capabilities = ["read"]
+    }
+
+    # Enable and manage the all secret engines at `*` path
+
+    # List, create, update, and delete secrets in all engines
+    path "*"
+    {
+      capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+    }
+
+    # Manage secrets engines
+    path "sys/mounts/*"
+    {
+      capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+    }
+
+    # List existing secrets engines.
+    path "sys/mounts"
+    {
+      capabilities = ["read"]
+    }
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -53,12 +86,18 @@ data:
     jwt=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
     token=$(vault write auth/kubernetes/login role=admin jwt="$jwt" | grep -m1 '^token' | awk '{ print $2 }')
     vault login -no-print -non-interactive "$token"
+  write-admin-policy.sh: |
+    echo "Writing admin policy"
+    vault policy write admin /policies/admin-policy.hcl
   {{- if .Values.oidc.enabled }}
   enable-oidc.sh: |
     set -euo pipefail
 
     echo "Checking if OIDC is already enabled"
-    if vault auth list | grep -q ^oidc/; then
+    set +e
+    status=$(vault auth list | grep 'oidc' | awk '{ print $1 }')
+    set -e
+    if [ "$status" == "oidc/" ]; then
       echo "OIDC is already enabled"
     else
       echo "OIDC is not enabled; enabling it now"
@@ -75,12 +114,12 @@ data:
     mount_accessor=$(vault auth list | awk '{ if ($1 == "oidc/") { print $3 } }')
     echo "  mount accessor: $mount_accessor"
 
-    echo "Writing 'admins' group"
-    group_id=$(vault write identity/group name=admins policies=admin type=external | awk '{ if ($1 == "id") { print $2 } }')
-    echo "  group id: $group_id"
+    echo "Writing 'admin' user"
+    entity_id=$(vault write identity/entity name=admin policies=admin | awk '{ if ($1 == "id") { print $2 } }')
+    echo "  entity id: $entity_id"
 
-    echo "Writing 'admins' group alias for plural OIDC; external group: {{ .Values.oidc.external_group_name }}"
-    vault write identity/group-alias name="{{ .Values.oidc.external_group_name }}" canonical_id="$group_id" mount_accessor="$mount_accessor"
+    echo "Writing 'admin' alias for plural OIDC; email: {{ .Values.oidc.adminEmail }}"
+    vault write identity/entity-alias name="{{ .Values.oidc.adminEmail }}" canonical_id="$entity_id" mount_accessor="$mount_accessor"
 
     echo "OIDC successfully configured"
   {{- end }}

--- a/vault/helm/vault/values.yaml
+++ b/vault/helm/vault/values.yaml
@@ -112,3 +112,8 @@ vault:
     #   - < YOUR SINGLE IP Ex. 1.78.23.3/32 >
 
 envSecret: {}
+
+oidc:
+  enabled: false
+  redirectHostname: ""
+  adminEmail: ""

--- a/vault/helm/vault/values.yaml.tpl
+++ b/vault/helm/vault/values.yaml.tpl
@@ -58,7 +58,5 @@ oidc:
 {{- if .OIDC }}
   enabled: true
   redirectHostname: {{ .Values.hostname }}
-  external_group_name: vault-admins
-{{ else }}
-  enabled: false
+  adminEmail: {{ .Config.Email }}
 {{- end }}


### PR DESCRIPTION
## Summary
This PR fixes the Vault admin permissions and adds a script that ensures they are updated before executing following commands. It also changes the OIDC behavior so that the Plural user that deployed Vault gets bound to the admin policy when OIDC is enabled.