### PR TITLE
Configurable subnets for the cluster and workers

### DIFF
--- a/bootstrap/terraform/aws-bootstrap/deps.yaml
+++ b/bootstrap/terraform/aws-bootstrap/deps.yaml
@@ -2,7 +2,7 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: Creates an EKS cluster and prepares it for bootstrapping
-  version: 0.1.38
+  version: 0.1.39
 spec:
   dependencies: []
   providers:

--- a/bootstrap/terraform/aws-bootstrap/main.tf
+++ b/bootstrap/terraform/aws-bootstrap/main.tf
@@ -7,9 +7,9 @@ module "vpc" {
   name                   = var.vpc_name
   cidr                   = "10.0.0.0/16"
   azs                    = data.aws_availability_zones.available.names
-  public_subnets         = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
-  private_subnets        = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  worker_private_subnets = ["10.0.16.0/20", "10.0.32.0/20", "10.0.48.0/20"]
+  public_subnets         = var.public_subnets
+  private_subnets        = var.private_subnets
+  worker_private_subnets = var.worker_private_subnets
   enable_dns_hostnames   = true
   enable_ipv6            = true
 

--- a/bootstrap/terraform/aws-bootstrap/variables.tf
+++ b/bootstrap/terraform/aws-bootstrap/variables.tf
@@ -14,6 +14,27 @@ variable "cluster_name" {
   description = "name for the cluster"
 }
 
+variable "public_subnets" {
+  type = list(string)
+  default = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+
+  description = "Public subnets for the EKS cluster"
+}
+
+variable "private_subnets" {
+  type = list(string)
+  default = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+
+  description = "Private subnets for the EKS cluster"
+}
+
+variable "worker_private_subnets" {
+  type = list(string)
+  default = ["10.0.16.0/20", "10.0.32.0/20", "10.0.48.0/20"]
+
+  description = "Private subnets for the workers of the EKS cluster"
+}
+
 variable "instance_types" {
   type = list(string)
   default = ["t3.large"]


### PR DESCRIPTION
## Summary
Set the subnets CIDRs for the EKS cluster and the worker nodes via a variable so user can easily configure them if they need to.


## Test Plan
Local linking.
