### PR TITLE
vault gcp: ensure keyring is unique as it is immutable

### DIFF
--- a/vault/terraform/gcp/deps.yaml
+++ b/vault/terraform/gcp/deps.yaml
@@ -2,7 +2,7 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: vault gcp setup
-  version: 0.1.1
+  version: 0.1.2
 spec:
   dependencies:
   - name: gcp-bootstrap

--- a/vault/terraform/gcp/deps.yaml
+++ b/vault/terraform/gcp/deps.yaml
@@ -4,6 +4,7 @@ metadata:
   description: vault gcp setup
   version: 0.1.2
 spec:
+  breaking: true
   dependencies:
   - name: gcp-bootstrap
     repo: bootstrap

--- a/vault/terraform/gcp/main.tf
+++ b/vault/terraform/gcp/main.tf
@@ -53,9 +53,12 @@ resource "google_kms_key_ring_iam_binding" "vault_iam_kms_binding" {
   ]
 }
 
+resource "random_uuid" "keyring" {
+}
+
 resource "google_kms_key_ring" "vault" {
   project  = "${var.project_id}"
-  name     = "${var.cluster_name}-vault"
+  name     = "${var.cluster_name}-vault-${random_uuid.keyring.result}"
   location = "${var.keyring_location}"
 
   depends_on = [


### PR DESCRIPTION
## Summary
Fixes an issue where after a `plural destroy` and redeploy the KMS keyring already exists since these are immutable on GCP. This is a breaking change since for existing users it could lock them out of their Vault deployment.


## Test Plan
local linking