### PR TITLE
Fix airflow names, make them restricted

### DIFF
--- a/.github/workflows/matrix-vendor-and-publish.yml
+++ b/.github/workflows/matrix-vendor-and-publish.yml
@@ -166,6 +166,7 @@ jobs:
       uses: pluralsh/setup-plural@v0.1.3
       with: 
         config: ${{ secrets.PLURAL_CONF }}
+        vsn: 0.3.17
     - run: plural apply -f ${{ matrix.pluralfile }}
     - uses: 8398a7/action-slack@v3
       with:

--- a/airflow/plural/recipes/aws-airflow.yaml
+++ b/airflow/plural/recipes/aws-airflow.yaml
@@ -1,6 +1,7 @@
-name: aws-airflow
+name: airflow-aws
 description: Installs airflow on an EKS cluster
 provider: AWS
+restricted: true
 oidcSettings:
   authMethod: POST
   uriFormat: https://{domain}/oauth-authorized/plural

--- a/airflow/plural/recipes/azure-airflow.yaml
+++ b/airflow/plural/recipes/azure-airflow.yaml
@@ -1,6 +1,7 @@
-name: azure-airflow
+name: airflow-azure
 description: Installs airflow on an AKS cluster
 provider: AZURE
+restricted: true
 oidcSettings:
   authMethod: POST
   uriFormat: https://{domain}/oauth-authorized/plural

--- a/airflow/plural/recipes/gcp-airflow.yaml
+++ b/airflow/plural/recipes/gcp-airflow.yaml
@@ -1,6 +1,7 @@
-name: gcp-airflow
+name: airflow-gcp
 description: Installs airflow on a GKE cluster
 provider: GCP
+restricted: true
 oidcSettings:
   authMethod: POST
   uriFormat: https://{domain}/oauth-authorized/plural


### PR DESCRIPTION
## Summary
airflow is currently not installable in cloud shell, so we should make that explicit

## Test Plan
n/a


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.