### PR TITLE
Add postgres wait init containers to airbyte app

### DIFF
--- a/airbyte/helm/airbyte/Chart.yaml
+++ b/airbyte/helm/airbyte/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: airbyte
 description: Unified data integration platform
 type: application
-version: 0.2.22
+version: 0.2.23
 appVersion: "1.16.0"
 dependencies:
   - name: airbyte

--- a/airbyte/helm/airbyte/charts/airbyte/templates/bootloader/pod.yaml
+++ b/airbyte/helm/airbyte/charts/airbyte/templates/bootloader/pod.yaml
@@ -11,6 +11,11 @@ metadata:
 spec:
   serviceAccountName: {{ include "airbyte.serviceAccountName" . }}
   restartPolicy: Never
+  initContainers:
+  - name: wait-for-pg
+    image: gcr.io/pluralsh/busybox:latest
+    imagePullPolicy: IfNotPresent
+    command: [ "/bin/sh", "-c", "until nc -zv {{ include "airbyte.database.host" . }} 5432 -w1; do echo 'waiting for db'; sleep 1; done" ]
   containers:
     - name: airbyte-bootloader-container
       image: {{ include "airbyte.bootloaderImage" . }}

--- a/airbyte/helm/airbyte/charts/airbyte/templates/scheduler/deployment.yaml
+++ b/airbyte/helm/airbyte/charts/airbyte/templates/scheduler/deployment.yaml
@@ -25,6 +25,11 @@ spec:
       {{- if .Values.scheduler.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.scheduler.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      initContainers:
+      - name: wait-for-pg
+        image: gcr.io/pluralsh/busybox:latest
+        imagePullPolicy: IfNotPresent
+        command: [ "/bin/sh", "-c", "until nc -zv {{ include "airbyte.database.host" . }} 5432 -w1; do echo 'waiting for db'; sleep 1; done" ]
       containers:
       - name: airbyte-scheduler-container
         image: {{ include "airbyte.schedulerImage" . }}

--- a/airbyte/helm/airbyte/charts/airbyte/templates/server/deployment.yaml
+++ b/airbyte/helm/airbyte/charts/airbyte/templates/server/deployment.yaml
@@ -29,6 +29,11 @@ spec:
       {{- if .Values.server.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.server.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      initContainers:
+      - name: wait-for-pg
+        image: gcr.io/pluralsh/busybox:latest
+        imagePullPolicy: IfNotPresent
+        command: [ "/bin/sh", "-c", "until nc -zv {{ include "airbyte.database.host" . }} 5432 -w1; do echo 'waiting for db'; sleep 1; done" ]
       containers:
       - name: airbyte-server-container
         image: {{ include "airbyte.serverImage" . }}

--- a/airbyte/helm/airbyte/charts/airbyte/templates/webapp/deployment.yaml
+++ b/airbyte/helm/airbyte/charts/airbyte/templates/webapp/deployment.yaml
@@ -29,6 +29,11 @@ spec:
       {{- if .Values.webapp.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.webapp.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      initContainers:
+      - name: wait-for-pg
+        image: gcr.io/pluralsh/busybox:latest
+        imagePullPolicy: IfNotPresent
+        command: [ "/bin/sh", "-c", "until nc -zv {{ include "airbyte.database.host" . }} 5432 -w1; do echo 'waiting for db'; sleep 1; done" ]
       containers:
       - name: airbyte-webapp-container
         image: {{ include "airbyte.webappImage" . }}

--- a/airbyte/helm/airbyte/charts/airbyte/templates/worker/deployment.yaml
+++ b/airbyte/helm/airbyte/charts/airbyte/templates/worker/deployment.yaml
@@ -27,6 +27,11 @@ spec:
       {{- if .Values.worker.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.worker.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      initContainers:
+      - name: wait-for-pg
+        image: gcr.io/pluralsh/busybox:latest
+        imagePullPolicy: IfNotPresent
+        command: [ "/bin/sh", "-c", "until nc -zv {{ include "airbyte.database.host" . }} 5432 -w1; do echo 'waiting for db'; sleep 1; done" ]
       containers:
       - name: airbyte-worker-container
         image: {{ include "airbyte.workerImage" . }}


### PR DESCRIPTION
## Summary

We're seeing occasional issues waiting for airbyte migrations which might be due to race conditions with postgres provisioning, this should serialize the process a bit and make it more reliable/debuggable


## Test Plan
tested using plural link

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.