### PR TITLE
change oauth2-proxy sidecar resources

### DIFF
--- a/bootstrap/helm/bootstrap/Chart.yaml
+++ b/bootstrap/helm/bootstrap/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 maintainers:
 - name: michaeljguarino
   email: mguarino46@gmail.com
-version: 0.8.45
+version: 0.8.46
 dependencies:
 - name: external-dns
   version: 4.11.0

--- a/bootstrap/helm/bootstrap/templates/configmap.yaml
+++ b/bootstrap/helm/bootstrap/templates/configmap.yaml
@@ -10,11 +10,10 @@ data:
       imagePullPolicy: IfNotPresent
       resources:
         requests:
-          cpu: 10m
-          memory: 20Mi
+          cpu: 25m
+          memory: 50Mi
         limits:
-          cpu: 10m
-          memory: 20Mi
+          memory: 50Mi
       ports:
       - name: oauth-http
         containerPort: 4180


### PR DESCRIPTION
## Summary
This PR increases the memory request and limit for OAuth2-Proxy sidecars that are inject, along with removing the CPU limit. This is necessary since it can cause huge amount of throttling when basic auth is used with OAuth2-Proxy. Furthermore, it's actually recommended too not use CPU limits within Kubernetes since containers are guaranteed the CPU they've requested (unlike with memory). 