### PR TITLE
increase nginx memory request

### DIFF
--- a/ingress-nginx/helm/ingress-nginx-private/Chart.yaml
+++ b/ingress-nginx/helm/ingress-nginx-private/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ingress-nginx-private
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.14
+version: 0.1.15
 appVersion: "1.1.0"
 dependencies:
 - name: ingress-nginx

--- a/ingress-nginx/helm/ingress-nginx-private/values.yaml
+++ b/ingress-nginx/helm/ingress-nginx-private/values.yaml
@@ -52,7 +52,6 @@ ingress-nginx:
       enabled: true
       minReplicas: 2
       maxReplicas: 11
-      targetCPUUtilizationPercentage: 50
       targetMemoryUtilizationPercentage: 95
       behavior:
         scaleDown:

--- a/ingress-nginx/helm/ingress-nginx/Chart.yaml
+++ b/ingress-nginx/helm/ingress-nginx/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ingress-nginx
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.9
+version: 0.1.10
 appVersion: "1.1.0"
 dependencies:
 - name: ingress-nginx

--- a/ingress-nginx/helm/ingress-nginx/values.yaml
+++ b/ingress-nginx/helm/ingress-nginx/values.yaml
@@ -26,7 +26,7 @@ ingress-nginx:
     resources:
       requests:
         cpu: 100m
-        memory: 120Mi
+        memory: 250Mi
     topologySpreadConstraints:
     - maxSkew: 1
       topologyKey: topology.kubernetes.io/zone
@@ -38,7 +38,6 @@ ingress-nginx:
       enabled: true
       minReplicas: 2
       maxReplicas: 11
-      targetCPUUtilizationPercentage: 50
       targetMemoryUtilizationPercentage: 95
       behavior:
         scaleDown:


### PR DESCRIPTION
## Summary
Taking a look at historical NGINX resource consumption it's apparent the request should be set higher too reduce the number of replicas that are running. Currently it's often scaled too the max number of replicas constantly.
