### PR TITLE
remove cpu from nginx HPA

### DIFF
--- a/ingress-nginx/helm/ingress-nginx-private/Chart.yaml
+++ b/ingress-nginx/helm/ingress-nginx-private/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ingress-nginx-private
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.15
+version: 0.1.16
 appVersion: "1.1.0"
 dependencies:
 - name: ingress-nginx

--- a/ingress-nginx/helm/ingress-nginx-private/values.yaml
+++ b/ingress-nginx/helm/ingress-nginx-private/values.yaml
@@ -40,7 +40,7 @@ ingress-nginx:
     resources:
       requests:
         cpu: 100m
-        memory: 120Mi
+        memory: 180Mi
     topologySpreadConstraints:
     - maxSkew: 1
       topologyKey: topology.kubernetes.io/zone
@@ -52,6 +52,7 @@ ingress-nginx:
       enabled: true
       minReplicas: 2
       maxReplicas: 11
+      targetCPUUtilizationPercentage: ""
       targetMemoryUtilizationPercentage: 95
       behavior:
         scaleDown:

--- a/ingress-nginx/helm/ingress-nginx/Chart.yaml
+++ b/ingress-nginx/helm/ingress-nginx/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ingress-nginx
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.10
+version: 0.1.11
 appVersion: "1.1.0"
 dependencies:
 - name: ingress-nginx

--- a/ingress-nginx/helm/ingress-nginx/values.yaml
+++ b/ingress-nginx/helm/ingress-nginx/values.yaml
@@ -38,6 +38,7 @@ ingress-nginx:
       enabled: true
       minReplicas: 2
       maxReplicas: 11
+      targetCPUUtilizationPercentage: ""
       targetMemoryUtilizationPercentage: 95
       behavior:
         scaleDown:


### PR DESCRIPTION
## Summary
Removes the CPU metric from the NGINX HPAs and bumps the memory request on the internal ingress slightly to avoid unneeded scale ups.