### PR TITLE
Bootstrap AWS: output complete vpc object and allow for enabling db subnets

### DIFF
--- a/bootstrap/terraform/aws-bootstrap/deps.yaml
+++ b/bootstrap/terraform/aws-bootstrap/deps.yaml
@@ -2,7 +2,7 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: Creates an EKS cluster and prepares it for bootstrapping
-  version: 0.1.39
+  version: 0.1.40
 spec:
   dependencies: []
   providers:
@@ -18,5 +18,6 @@ spec:
     worker_role_arn: worker_role_arn
     node_groups: node_groups
     cluster_oidc_issuer_url: cluster_oidc_issuer_url
+    vpc: vpc
   provider_wirings:
     cluster: module.aws-bootstrap.cluster_name

--- a/bootstrap/terraform/aws-bootstrap/main.tf
+++ b/bootstrap/terraform/aws-bootstrap/main.tf
@@ -13,6 +13,8 @@ module "vpc" {
   enable_dns_hostnames   = true
   enable_ipv6            = true
 
+  database_subnets = var.database_subnets
+
   enable_nat_gateway = true
   single_nat_gateway = true
 

--- a/bootstrap/terraform/aws-bootstrap/output.tf
+++ b/bootstrap/terraform/aws-bootstrap/output.tf
@@ -42,3 +42,7 @@ output "worker_role_arn" {
 output "node_groups" {
   value = [for d in merge(module.single_az_node_groups.node_groups, module.multi_az_node_groups.node_groups): d]
 }
+
+output "vpc" {
+  value = module.vpc
+}

--- a/bootstrap/terraform/aws-bootstrap/terraform.tfvars
+++ b/bootstrap/terraform/aws-bootstrap/terraform.tfvars
@@ -8,3 +8,11 @@ map_roles = [
     groups = ["system:masters"]
   }
 ]
+
+
+{{- if .Values.database_subnets }}
+database_subnets = yamldecode(<<EOT
+{{ .Values.database_subnets | toYaml }}
+EOT
+)
+{{- end }}

--- a/bootstrap/terraform/aws-bootstrap/variables.tf
+++ b/bootstrap/terraform/aws-bootstrap/variables.tf
@@ -42,6 +42,13 @@ variable "worker_private_subnets" {
   description = "Private subnets for the workers of the EKS cluster"
 }
 
+variable "database_subnets" {
+  type = list(string)
+  default = []
+
+  description = "A list of database subnets"
+}
+
 variable "instance_types" {
   type = list(string)
   default = ["t3.large"]


### PR DESCRIPTION
## Summary
This PR outputs the complete VPC object from our AWS bootstrap terraform and allows users to create database subnets. Users can do this by adding a list of subnets under the `database_subnets` key for bootstrap in the `context.yaml`. For example:

```yaml
spec:  
  configuration:
    bootstrap:
      database_subnets:
      - "10.0.64.0/24"
```