### PR TITLE
Add SMTP configuration for jitsu

### DIFF
--- a/jitsu/helm/jitsu/Chart.yaml
+++ b/jitsu/helm/jitsu/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: jitsu
 description: helm chart for jitsu
 type: application
-version: 0.1.15
+version: 0.1.16
 appVersion: 1.41.5

--- a/jitsu/helm/jitsu/templates/deployment.yaml
+++ b/jitsu/helm/jitsu/templates/deployment.yaml
@@ -13,8 +13,9 @@ spec:
       {{- include "jitsu.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        config/checksum: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:

--- a/jitsu/helm/jitsu/templates/secret.yaml
+++ b/jitsu/helm/jitsu/templates/secret.yaml
@@ -12,6 +12,9 @@ stringData:
   USER_RECOGNITION_REDIS_URL: redis://:{{ .Values.secrets.redis_password }}@{{ .Values.secrets.redis_host }}:6379
   TLS_SKIP_VERIFY: 'true'
   TERM: xterm-256color
+  {{ if .Values.secrets.smtp }}
+  JITSU_SMTP_CONFIG: {{ toJson .Values.secrets.smtp | quote }}
+  {{ end }}
 ---
 apiVersion: v1
 kind: Secret

--- a/jitsu/helm/jitsu/values.yaml.tpl
+++ b/jitsu/helm/jitsu/values.yaml.tpl
@@ -14,6 +14,14 @@ secrets:
   redis_password: {{ $redisValues.redis.password }}
   admin_token: {{ dedupe . "jitsu.jitsu.secrets.admin_token" (randAlphaNum 32) }}
   configurator_url: https://{{ .Values.hostname }}/configurator
+  {{ if .SMTP }}
+  smtp:
+    user: {{ .SMTP.User }}
+    password: {{ .SMTP.Password }}
+    host: {{ .SMTP.Server }}
+    port: {{ .SMTP.Port }}
+    from: {{ .SMTP.Sender }}
+  {{ end }}
 
 config:
   server:


### PR DESCRIPTION
## Summary
Dignifi health are requesting this to be set up


## Test Plan
tested using plural link


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [x]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [x]  All major clouds must be supported
    - [x]  Azure
    - [x]  AWS
    - [x]  GCP