### PR TITLE
Add default read-only role to argo-workflow sso

### DIFF
--- a/argo-workflows/helm/argo-workflows/Chart.yaml
+++ b/argo-workflows/helm/argo-workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.22
+version: 0.1.23
 appVersion: "v3.2.9"
 dependencies:
 - name: argo-workflows

--- a/argo-workflows/helm/argo-workflows/templates/serviceaccount.yaml
+++ b/argo-workflows/helm/argo-workflows/templates/serviceaccount.yaml
@@ -14,6 +14,17 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  name: argo-workflow-admin
+  labels:
+    {{- include "argo-workflows-plural.labels" . | nindent 4 }}
+  {{- with .Values.adminServiceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
   name: argo-workflow-read
   labels:
   {{ include "argo-workflows-plural.labels" . | nindent 4 }}

--- a/argo-workflows/helm/argo-workflows/templates/serviceaccount.yaml
+++ b/argo-workflows/helm/argo-workflows/templates/serviceaccount.yaml
@@ -9,4 +9,14 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+---
 {{- end }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argo-workflow-read
+  labels:
+  {{ include "argo-workflows-plural.labels" . | nindent 4 }}
+  annotations:
+    workflows.argoproj.io/rbac-rule: "true"
+    workflows.argoproj.io/rbac-rule-precedence: "0"

--- a/argo-workflows/helm/argo-workflows/templates/workflow-rbac.yaml
+++ b/argo-workflows/helm/argo-workflows/templates/workflow-rbac.yaml
@@ -10,6 +10,9 @@ subjects:
   - kind: ServiceAccount
     name: argo-workflow
     namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: argo-workflow-admin
+    namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/argo-workflows/helm/argo-workflows/templates/workflow-rbac.yaml
+++ b/argo-workflows/helm/argo-workflows/templates/workflow-rbac.yaml
@@ -12,6 +12,19 @@ subjects:
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argo-workflow-read-only-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo-workflow-read-only-role
+subjects:
+  - kind: ServiceAccount
+    name: argo-workflow-read
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: argo-workflow-admin-role
@@ -100,3 +113,60 @@ rules:
   - create
   - get
   - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argo-workflow-read-only-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/exec
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  - workflows/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflowtemplates
+  - workflowtemplates/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - cronworkflows
+  - cronworkflows/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list

--- a/argo-workflows/helm/argo-workflows/values.yaml
+++ b/argo-workflows/helm/argo-workflows/values.yaml
@@ -1,5 +1,9 @@
 serviceAccount:
   create: false
+
+adminServiceAccount:
+  annotations: {}
+
 oidcSecret:
   clientID: ""
   clientSecret: ""

--- a/argo-workflows/helm/argo-workflows/values.yaml.tpl
+++ b/argo-workflows/helm/argo-workflows/values.yaml.tpl
@@ -87,7 +87,11 @@ serviceAccount:
   create: true
   annotations:
     {{- if .OIDC }}
+    {{ if .Values.adminGroup }}
+    workflows.argoproj.io/rbac-rule: "'{{ .Values.adminGroup }}' in groups"
+    {{ else }}
     workflows.argoproj.io/rbac-rule: "email in ['{{ .Values.adminEmail }}']"
+    {{ end }}
     workflows.argoproj.io/rbac-rule-precedence: "1"
     {{- end }}
     {{- if eq .Provider "aws" }}

--- a/argo-workflows/helm/argo-workflows/values.yaml.tpl
+++ b/argo-workflows/helm/argo-workflows/values.yaml.tpl
@@ -83,17 +83,19 @@ artifactRepository:
   gcs:
     bucket: {{ .Values.workflowBucket | quote }}
   {{ end }}
-serviceAccount:
-  create: true
+{{- if .OIDC }}
+adminServiceAccount:
   annotations:
-    {{- if .OIDC }}
     {{ if .Values.adminGroup }}
     workflows.argoproj.io/rbac-rule: "'{{ .Values.adminGroup }}' in groups"
     {{ else }}
     workflows.argoproj.io/rbac-rule: "email in ['{{ .Values.adminEmail }}']"
     {{ end }}
     workflows.argoproj.io/rbac-rule-precedence: "1"
-    {{- end }}
+{{- end }}
+serviceAccount:
+  create: true
+  annotations:
     {{- if eq .Provider "aws" }}
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Project }}:role/{{ .Cluster }}-argo-workflows"
     {{- end }}

--- a/argo-workflows/plural/recipes/argo-workflows-aws.yaml
+++ b/argo-workflows/plural/recipes/argo-workflows-aws.yaml
@@ -21,6 +21,10 @@ sections:
   - name: adminEmail
     documentation: email address for the admin user
     type: STRING
+  - name: adminGroup
+    documentation: specify a user group to grant admin rights to
+    type: STRING
+    optional: true 
   items:
   - type: TERRAFORM
     name: aws

--- a/argo-workflows/plural/recipes/argo-workflows-azure.yaml
+++ b/argo-workflows/plural/recipes/argo-workflows-azure.yaml
@@ -21,6 +21,10 @@ sections:
   - name: adminEmail
     documentation: email address for the admin user
     type: STRING
+  - name: adminGroup
+    documentation: specify a user group to grant admin rights to
+    type: STRING
+    optional: true
   items:
   - type: TERRAFORM
     name: azure

--- a/argo-workflows/plural/recipes/argo-workflows-gcp.yaml
+++ b/argo-workflows/plural/recipes/argo-workflows-gcp.yaml
@@ -21,6 +21,10 @@ sections:
   - name: adminEmail
     documentation: email address for the admin user
     type: STRING
+  - name: adminGroup
+    documentation: specify a user group to grant admin rights to
+    type: STRING
+    optional: true
   items:
   - type: TERRAFORM
     name: gcp


### PR DESCRIPTION
## Summary

Argo has the capability to provide a default role to sso users, which can naturally be made a RO role so users can use the workflow dashboard for visibility.  We should configure that properly by default.



## Test Plan
verified with plural link


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP