### PR TITLE
Update app descriptions

### DIFF
--- a/airbyte/repository.yaml
+++ b/airbyte/repository.yaml
@@ -1,5 +1,5 @@
 name: airbyte
-description: unified data integration platform
+description: An open-source data integration engine for modern data teams.
 category: DATA
 icon: plural/icons/airbyte.png
 notes: plural/notes.tpl

--- a/airflow/repository.yaml
+++ b/airflow/repository.yaml
@@ -1,5 +1,5 @@
 name: airflow
-description: DAG-based dependency aware job scheduler
+description: Open-source workflow management system that allows data engineers to orchestrate sequenceable tasks.
 category: DATA
 icon: plural/icons/airflow.png
 notes: plural/notes.tpl

--- a/argo-cd/repository.yaml
+++ b/argo-cd/repository.yaml
@@ -1,5 +1,5 @@
 name: argo-cd
-description: Declarative continuous deployment for Kubernetes.
+description: A declarative, GitOps continuous delivery tool for Kubernetes.
 category: DEVOPS
 icon: plural/icons/argo-stacked-color-square.png
 notes: plural/notes.tpl

--- a/argo-workflows/repository.yaml
+++ b/argo-workflows/repository.yaml
@@ -1,5 +1,5 @@
 name: argo-workflows
-description: The workflow engine for Kubernetes
+description: An open source container-native workflow engine for orchestrating parallel jobs on Kubernetes.
 category: DEVOPS
 icon: plural/icons/argo-stacked-color-square.png
 notes: plural/notes.tpl

--- a/bootstrap/repository.yaml
+++ b/bootstrap/repository.yaml
@@ -1,5 +1,5 @@
 name: bootstrap
-description: cluster initialization resources for plural
+description: The Helm, Terraform, and YAML required to get started with Kubernetes.
 icon: plural/icons/k8s.png
 category: DEVOPS
 tags:

--- a/bootstrap/repository.yaml
+++ b/bootstrap/repository.yaml
@@ -1,5 +1,5 @@
 name: bootstrap
-description: The Helm, Terraform, and YAML required to get started with Kubernetes.
+description: The cluster initialization resources for Plural.
 icon: plural/icons/k8s.png
 category: DEVOPS
 tags:

--- a/bootstrap/repository.yaml
+++ b/bootstrap/repository.yaml
@@ -6,3 +6,4 @@ tags:
 - tag: externaldns
 - tag: ingress
 - tag: kubernetes
+- tag: auto-include

--- a/calendso/repository.yaml
+++ b/calendso/repository.yaml
@@ -1,5 +1,5 @@
 name: calendso
-description: open source calendly alternative
+description: An open-source alternative to Calendly.
 category: PRODUCTIVITY
 private: true
 icon: plural/icons/cal.png

--- a/chatwoot/repository.yaml
+++ b/chatwoot/repository.yaml
@@ -1,5 +1,5 @@
 name: chatwoot
-description: open-source, self-hosted customer engagement suite
+description: An open-source and self-hosted customer engagement suite.
 category: PRODUCTIVITY
 icon: plural/icons/chatwoot.png
 notes: plural/notes.tpl

--- a/crossplane/repository.yaml
+++ b/crossplane/repository.yaml
@@ -1,5 +1,5 @@
 name: crossplane
-description: crd based cloud resource deployment
+description: An open-source Kubernetes add-on that transforms your cluster into a universal control plane.
 category: DEVOPS
 icon: plural/icons/crossplane.png
 notes: plural/notes.tpl

--- a/dagster/repository.yaml
+++ b/dagster/repository.yaml
@@ -1,5 +1,5 @@
 name: dagster
-description: beautiful data processing workflows
+description: A data orchestration platform for the development, production, and observation of data assets.
 category: DATA
 private: false
 icon: plural/icons/dagster.png

--- a/datadog/repository.yaml
+++ b/datadog/repository.yaml
@@ -1,5 +1,5 @@
 name: datadog
-description: datadog deployed on plural
+description: An observability service for cloud-scale applications.
 category: DEVOPS
 private: false
 gitUrl: https://github.com/DataDog/helm-charts

--- a/dex/repository.yaml
+++ b/dex/repository.yaml
@@ -1,5 +1,5 @@
 name: dex
-description: federated identity provider for modern authentication
+description: An identity service that uses OpenID connect to drive authentication for other apps.
 category: DEVOPS
 icon: plural/icons/dex.png
 notes: plural/notes.tpl

--- a/etcd/repository.yaml
+++ b/etcd/repository.yaml
@@ -1,5 +1,5 @@
 name: etcd
-description: a strongly consistent, distributed key-value store
+description: A distributed reliable key-value store for the most critical data of a distributed system.
 category: DATABASE
 icon: plural/icons/etcd-logo.png
 homepage: https://etcd.io/

--- a/filecoin/repository.yaml
+++ b/filecoin/repository.yaml
@@ -1,5 +1,5 @@
 name: filecoin
-description: making the web more secure and efficient with a decentralized data storage marketplace, protocol, and cryptocurrency.
+description: A decentralized storage network for renting unused hard disk space.
 category: DEVOPS
 icon: plural/icons/filecoin.png
 notes: plural/notes.tpl

--- a/gcp-config-connector/repository.yaml
+++ b/gcp-config-connector/repository.yaml
@@ -1,5 +1,5 @@
 name: gcp-config-connector
-description: gcp-config-connector deployed on plural
+description: An open-source Kubernetes add-on that allows users to manage GCP resources through Kubernetes.
 category: DEVOPS
 private: true
 icon: plural/icons/gcp.png

--- a/ghost/repository.yaml
+++ b/ghost/repository.yaml
@@ -1,5 +1,5 @@
 name: ghost
-description: open source blog platform
+description: An open-source app that allows creators to publish, share, and grow a business around their content.
 category: PRODUCTIVITY
 icon: plural/icons/ghost.png
 notes: plural/notes.tpl

--- a/gitlab/repository.yaml
+++ b/gitlab/repository.yaml
@@ -1,5 +1,5 @@
 name: gitlab
-description: unified devops experience based on git
+description: Source control management tool with built-in CI/CD and DevOps solutions.
 category: DEVOPS
 icon: plural/icons/gitlab.png
 notes: plural/notes.tpl

--- a/goldilocks/repository.yaml
+++ b/goldilocks/repository.yaml
@@ -1,5 +1,5 @@
 name: goldilocks
-description: resource scaling assistant
+description: A K8s controller that provides a dashboard with guidance for setting up your resource requests.
 category: DEVOPS
 icon: plural/icons/goldilocks.png
 notes: plural/notes.tpl

--- a/grafana-tempo/repository.yaml
+++ b/grafana-tempo/repository.yaml
@@ -1,5 +1,5 @@
 name: grafana-tempo
-description: easy-to-use and high-scale distributed tracing backend
+description: An open-source high-scale distributed tracing backend.
 category: DEVOPS
 icon: plural/icons/tempo.png
 notes: plural/notes.tpl

--- a/grafana/repository.yaml
+++ b/grafana/repository.yaml
@@ -1,5 +1,5 @@
 name: grafana
-description: open source metrics visualization
+description: An open-source platform for monitoring and observability with interactive visualizations.
 category: DEVOPS
 icon: plural/icons/grafana.png
 notes: plural/notes.tpl

--- a/growthbook/repository.yaml
+++ b/growthbook/repository.yaml
@@ -1,5 +1,5 @@
 name: growthbook
-description: open source feature flagging toolkit
+description: An open-source feature flagging and experimentation platform.
 category: DATA
 private: false
 icon: plural/icons/growthbook.png

--- a/hasura/repository.yaml
+++ b/hasura/repository.yaml
@@ -1,5 +1,5 @@
 name: hasura
-description: open source instant graphql on all your data
+description: An open-source product that gives you GraphQL or REST APIs with built-in authorization on your data.
 category: DATA
 icon: plural/icons/hasura.png
 notes: plural/notes.tpl

--- a/hydra/repository.yaml
+++ b/hydra/repository.yaml
@@ -1,5 +1,5 @@
 name: hydra
-description: hydra deployed on plural
+description: Low latency, high-throughput OAuth 2.0 and OpenID Connect provider.
 category: SECURITY
 private: false
 icon: plural/icons/hydra.png

--- a/influx/repository.yaml
+++ b/influx/repository.yaml
@@ -1,5 +1,5 @@
 name: influx
-description: time series database and monitoring platform
+description: An open-source time-series database.
 category: DATABASE
 icon: plural/icons/influx.png
 notes: plural/notes.tpl

--- a/ingress-nginx/repository.yaml
+++ b/ingress-nginx/repository.yaml
@@ -1,5 +1,5 @@
 name: ingress-nginx
-description: NGINX Ingress Controller for Kubernetes
+description: An Ingress controller for Kubernetes that uses NGINX as a reverse proxy and load balancer.
 category: NETWORK
 icon: plural/icons/nginx.png
 notes: plural/notes.tpl

--- a/istio/repository.yaml
+++ b/istio/repository.yaml
@@ -1,5 +1,5 @@
 name: istio
-description: envoy powered service mesh
+description: An open-source service mesh platform that controls how microservices share data with one another.
 category: DEVOPS
 icon: plural/icons/istio.png
 homepage: https://istio.io/

--- a/jitsu/repository.yaml
+++ b/jitsu/repository.yaml
@@ -1,5 +1,5 @@
 name: jitsu
-description: jitsu deployed on plural
+description: An open-source high-performance data collection service.
 category: DATA
 private: false
 icon: plural/icons/jitsu.png

--- a/kafka/repository.yaml
+++ b/kafka/repository.yaml
@@ -1,5 +1,5 @@
 name: kafka
-description: high performance log database
+description: An open-source distributed event streaming platform.
 category: MESSAGING
 icon: plural/icons/kafka.png
 homepage: https://kafka.apache.org/

--- a/knative/repository.yaml
+++ b/knative/repository.yaml
@@ -1,5 +1,5 @@
 name: knative
-description: serverless for kubernetes
+description: An open-source enterprise-level solution to build serverless and event-driven applications.
 category: DEVOPS
 icon: plural/icons/knative.png
 gitUrl: https://github.com/knative/serving

--- a/kratos/repository.yaml
+++ b/kratos/repository.yaml
@@ -1,5 +1,5 @@
 name: kratos
-description: kratos deployed on plural
+description: A microservice framework in Go that acts like a toolbox for building microservices in Go.
 category: SECURITY
 private: true
 icon: plural/icons/kratos.png

--- a/kserve/repository.yaml
+++ b/kserve/repository.yaml
@@ -1,5 +1,5 @@
 name: kserve
-description: kserve deployed on plural
+description: KServe provides a K8s CRD for serving ML models on arbitrary frameworks.
 category: DATA
 private: false
 icon: plural/icons/kserve.png

--- a/kubecost/repository.yaml
+++ b/kubecost/repository.yaml
@@ -1,5 +1,5 @@
 name: kubecost
-description: kubernetes cost monitoring and management
+description: An open core tool that provides visibility into Kubernetes spend and resource allocation.
 category: DEVOPS
 icon: plural/icons/kubecost.png
 notes: plural/notes.tpl

--- a/kubeflow/repository.yaml
+++ b/kubeflow/repository.yaml
@@ -1,5 +1,5 @@
 name: kubeflow
-description: The Machine Learning Toolkit for Kubernetes
+description: A cloud-native platform for machine learning operations - pipelines, training, and deployment.
 category: DEVOPS
 icon: plural/icons/kubeflow.png
 notes: plural/notes.tpl

--- a/kubescape/repository.yaml
+++ b/kubescape/repository.yaml
@@ -1,5 +1,5 @@
 name: kubescape
-description: kubernetes security in a single pane of glass
+description: A Kubernetes open-source tool providing a multi-cloud K8s single pane of glass.
 category: SECURITY
 private: false
 icon: plural/icons/kubescape.png

--- a/kyverno/repository.yaml
+++ b/kyverno/repository.yaml
@@ -1,5 +1,5 @@
 name: kyverno
-description: Kubernetes Native Policy Management
+description: A policy engine designed for Kubernetes that can validate, mutate, and generate configurations.
 category: SECURITY
 icon: plural/icons/kyverno.png
 notes: plural/notes.tpl

--- a/lakefs/repository.yaml
+++ b/lakefs/repository.yaml
@@ -1,5 +1,5 @@
 name: lakefs
-description: lakefs deployed on plural
+description: An open-source business intelligence platform.
 category: DEVOPS
 private: true
 icon: plural/icons/lakefs.png

--- a/metabase/repository.yaml
+++ b/metabase/repository.yaml
@@ -1,5 +1,5 @@
 name: metabase
-description: democratized data investigation
+description: An easy, open-source way for everyone to ask questions and learn from data.
 category: DATA
 icon: plural/icons/metabase.png
 notes: plural/notes.tpl

--- a/minio/repository.yaml
+++ b/minio/repository.yaml
@@ -1,5 +1,5 @@
 name: minio
-description: High Performance, Kubernetes Native Object Storage
+description: A high-performance Kubernetes-native object storage that is compatible with the S3 API.
 category: DEVOPS
 icon: plural/icons/minio.png
 notes: plural/notes.tpl

--- a/mlflow/repository.yaml
+++ b/mlflow/repository.yaml
@@ -1,5 +1,5 @@
 name: mlflow
-description: streamlined machine learning development
+description: An open-source platform that streamlines machine learning development.
 category: DEVOPS
 icon: plural/icons/mlflow.png
 notes: plural/notes.tpl

--- a/mongodb/repository.yaml
+++ b/mongodb/repository.yaml
@@ -1,5 +1,5 @@
 name: mongodb
-description: scalable nosql document-oriented db
+description: A scalable NoSQL document-oriented database.
 category: DATABASE
 private: false
 icon: plural/icons/mongodb.png

--- a/monitoring/repository.yaml
+++ b/monitoring/repository.yaml
@@ -1,5 +1,5 @@
 name: monitoring
-description: openmetrics suite for plural
+description: An OpenMetrics suite for Plural.
 icon: plural/icons/monitoring.png
 category: DEVOPS
 gitUrl: https://github.com/prometheus/prometheus

--- a/mysql/repository.yaml
+++ b/mysql/repository.yaml
@@ -1,5 +1,5 @@
 name: mysql
-description: open source rdbms
+description: An open-source relational database management system.
 category: DATABASE
 icon: plural/icons/mysql.png
 notes: plural/notes.tpl

--- a/n8n/repository.yaml
+++ b/n8n/repository.yaml
@@ -1,5 +1,5 @@
 name: n8n
-description: n8n deployed on plural
+description: An extendable workflow automation tool.
 category: DATA
 private: false
 icon: plural/icons/n8n.png

--- a/nextcloud/repository.yaml
+++ b/nextcloud/repository.yaml
@@ -1,5 +1,5 @@
 name: nextcloud
-description: the first completely integrated on-premises content collaboration platform
+description: A completely integrated on-premises content collaboration platform.
 category: DEVOPS
 icon: plural/icons/nextcloud.png
 notes: plural/notes.tpl

--- a/nocodb/repository.yaml
+++ b/nocodb/repository.yaml
@@ -1,5 +1,5 @@
 name: nocodb
-description: turn any database into a realtime editable spreadsheet
+description: An open-source alternative to Airtable that turns any database into a smart spreadsheet.
 category: PRODUCTIVITY
 icon: plural/icons/nocodb.png
 notes: plural/notes.tpl

--- a/nvidia-operator/repository.yaml
+++ b/nvidia-operator/repository.yaml
@@ -1,5 +1,5 @@
 name: nvidia-operator
-description: Everything needed to schedule and monitor NVIDIA GPUs
+description: Allows administrators of Kubernetes clusters to manage GPU nodes just like CPU nodes in the cluster.
 category: DEVOPS
 icon: plural/icons/nvidia.png
 notes: plural/notes.tpl

--- a/oauth2-proxy/repository.yaml
+++ b/oauth2-proxy/repository.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-description: easy to use oauth solution for load balancers
+description: A reverse proxy & static file server that issues auth to validate accounts by email or domain.
 category: SECURITY
 icon: plural/icons/oauth2-proxy.png
 notes: plural/notes.tpl

--- a/postgres/repository.yaml
+++ b/postgres/repository.yaml
@@ -1,5 +1,5 @@
 name: postgres
-description: postgres as a service for kubernetes
+description: An open-source relational database that supports both SQL and JSON querying.
 icon: plural/icons/postgres.png
 category: DATABASE
 homepage: https://postgres-operator.readthedocs.io/en/latest/

--- a/rabbitmq/repository.yaml
+++ b/rabbitmq/repository.yaml
@@ -1,5 +1,5 @@
 name: rabbitmq
-description: deploys the rabbitmq operator and associated monitoring
+description: An open-source message broker.
 category: MESSAGING
 icon: plural/icons/rabbitmq.png
 homepage: https://www.rabbitmq.com/

--- a/redash/repository.yaml
+++ b/redash/repository.yaml
@@ -1,5 +1,5 @@
 name: redash
-description: redash deployed on plural
+description: Redash provides users with BI tools to query data sources and create visual dashboards.
 category: DATA
 private: true
 icon: plural/icons/redash.png

--- a/redis/repository.yaml
+++ b/redis/repository.yaml
@@ -1,5 +1,5 @@
 name: redis
-description: high performance in-memory object store
+description: An open-source, in-memory data structure store, used as a database, cache, and message broker
 category: DATABASE
 icon: plural/icons/redis.png
 notes: plural/notes.tpl

--- a/rook/repository.yaml
+++ b/rook/repository.yaml
@@ -1,5 +1,5 @@
 name: rook
-description: open source cloud-native storage orchestrator for Kubernetes
+description: An open-source cloud-native storage orchestrator for Kubernetes.
 category: DATA
 icon: plural/icons/rook.png
 notes: plural/notes.tpl

--- a/sentry/repository.yaml
+++ b/sentry/repository.yaml
@@ -1,5 +1,5 @@
 name: sentry
-description: error monitoring for multiple languages and platforms
+description: A developer-first error tracking and performance monitoring platform.
 icon: plural/icons/sentry.png
 category: DEVOPS
 notes: plural/notes.tpl

--- a/spark/repository.yaml
+++ b/spark/repository.yaml
@@ -1,5 +1,5 @@
 name: spark
-description: a unified analytics engine for large-scale data processing
+description: A unified analytics engine for large-scale data processing. 
 category: DATA
 icon: plural/icons/spark.png
 notes: plural/notes.tpl

--- a/strapi/repository.yaml
+++ b/strapi/repository.yaml
@@ -1,5 +1,5 @@
 name: strapi
-description: strapi deployed on plural
+description: An open-source headless CMS to build powerful APIs with little effort.
 category: DATA
 private: true
 icon: plural/icons/strapi.png

--- a/superset/repository.yaml
+++ b/superset/repository.yaml
@@ -1,5 +1,5 @@
 name: superset
-description: open source data visualization
+description: An open-source modern data exploration and visualization platform.
 category: DATA
 icon: plural/icons/superset.png
 notes: plural/notes.tpl

--- a/trino/repository.yaml
+++ b/trino/repository.yaml
@@ -1,5 +1,5 @@
 name: trino
-description: trino deployed on plural
+description: A distributed SQL query engine for big data and analytics.
 category: DATABASE
 private: false
 icon: plural/icons/trino.png

--- a/vault/repository.yaml
+++ b/vault/repository.yaml
@@ -1,5 +1,5 @@
 name: vault
-description: vault deployed on plural
+description: An open-source identity-based secrets and encryption management system.
 category: SECURITY
 private: false
 icon: plural/icons/vault.png

--- a/vaultwarden/repository.yaml
+++ b/vaultwarden/repository.yaml
@@ -1,5 +1,5 @@
 name: vaultwarden
-description: Unofficial Bitwarden compatible server written in Rust
+description: An open-source password management solution for individuals, teams, and business organizations.
 category: SECURITY
 icon: plural/icons/vaultwarden.png
 notes: plural/notes.tpl


### PR DESCRIPTION
## Summary
Related to ENG-465.

It updates app descriptions according to spreadsheet linked in [the issue](https://linear.app/pluralsh/issue/ENG-465/update-app-descriptions).

Some of descriptions were missing in the spreadsheet:
- Datadog (updated)
- GrowthBook (updated)
- KServe (updated)
- Lightdash (no update required)
- Metabase (updated)
- MongoDB (updated)
- Redash (updated)
- Yugabyte (`repository.yaml` is missing)

Some of them are not in this repo:
- ClickHouse
- Console
- Elasticsearch (`repository.yaml` is missing)
- Kubricks
- Loki
- Plural
- Renovate
- Test-Harness

I saw descriptions being in multiple places in our org. Should we update documentation (i.e. https://github.com/pluralsh/documentation/blob/main/repositories/airflow.md) repo as well?

See also my comments below.

## Test Plan

## Checklist
- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP