### PR TITLE
AWS: ensure node groups have a unique name

### DIFF
--- a/bootstrap/terraform/aws-bootstrap/deps.yaml
+++ b/bootstrap/terraform/aws-bootstrap/deps.yaml
@@ -2,8 +2,9 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: Creates an EKS cluster and prepares it for bootstrapping
-  version: 0.1.40
+  version: 0.1.41
 spec:
+  breaking: true
   dependencies: []
   providers:
   - aws

--- a/bootstrap/terraform/aws-bootstrap/main.tf
+++ b/bootstrap/terraform/aws-bootstrap/main.tf
@@ -54,7 +54,7 @@ module "cluster" {
 }
 
 module "single_az_node_groups" {
-  source                 = "github.com/pluralsh/module-library//terraform/eks-node-groups/single-az-node-groups?ref=7b6d3b1d1602e4265d6d3b172c38fe67d9a2c7fc"
+  source                 = "github.com/pluralsh/module-library//terraform/eks-node-groups/single-az-node-groups?ref=df068595c3e91590d11e1ace11e1d688630f03d6"
   cluster_name           = var.cluster_name
   default_iam_role_arn   = module.cluster.worker_iam_role_arn
   tags                   = {}
@@ -88,7 +88,7 @@ module "multi_az_node_groups" {
 resource "aws_eks_addon" "vpc_cni" {
   cluster_name = module.cluster.cluster_id
   addon_name   = "vpc-cni"
-  addon_version     = "v1.10.1-eksbuild.1"
+  addon_version     = "v1.11.3-eksbuild.1"
   resolve_conflicts = "OVERWRITE"
   tags = {
       "eks_addon" = "vpc-cni"
@@ -116,7 +116,7 @@ resource "aws_eks_addon" "core_dns" {
 resource "aws_eks_addon" "kube_proxy" {
   cluster_name      = module.cluster.cluster_id
   addon_name        = "kube-proxy"
-  addon_version     = "v1.21.2-eksbuild.2"
+  addon_version     = "v1.21.14-eksbuild.2"
   resolve_conflicts = "OVERWRITE"
   tags = {
       "eks_addon" = "kube-proxy"

--- a/bootstrap/terraform/aws-bootstrap/variables.tf
+++ b/bootstrap/terraform/aws-bootstrap/variables.tf
@@ -117,7 +117,7 @@ variable "node_groups_defaults" {
 
     instance_types = ["t3.large", "t3a.large"]
     disk_size = 50
-    ami_release_version = "1.21.5-20220123"
+    ami_release_version = "1.21.14-20220824"
     force_update_version = true
     ami_type = "AL2_x86_64"
     k8s_labels = {}


### PR DESCRIPTION
## Summary
When an AWS region only has 2 availability zones a duplicate name for our node groups occurs. This PR uses a new version of our node group module that appends the subnet name to the node group name to ensure they are unique. Since this is a breaking change, this is also a good opportunity to update the AMI used by the worker nodes. Also, the `kube-proxy` and `vpc-cni` versions are updated.


## Test Plan
local linking