### PR TITLE
Use forked postgres operator with liveness probes and fix backup lifecycle

### DIFF
--- a/postgres/helm/postgres/Chart.yaml
+++ b/postgres/helm/postgres/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: postgres
 description: A Helm chart for deploying the zalando postgres operator
 type: application
-version: 0.2.8
-appVersion: "1.16.0"
+version: 0.2.9
+appVersion: "1.8.2"

--- a/postgres/helm/postgres/crds/operatorconfigurations.yaml
+++ b/postgres/helm/postgres/crds/operatorconfigurations.yaml
@@ -4,8 +4,6 @@ metadata:
   name: operatorconfigurations.acid.zalan.do
   labels:
     app.kubernetes.io/name: postgres-operator
-  annotations:
-    "helm.sh/hook": crd-install
 spec:
   group: acid.zalan.do
   names:
@@ -63,11 +61,20 @@ spec:
           configuration:
             type: object
             properties:
+              crd_categories:
+                type: array
+                nullable: true
+                items:
+                  type: string
               docker_image:
                 type: string
-                default: "registry.opensource.zalan.do/acid/spilo-13:2.0-p7"
+                default: "registry.opensource.zalan.do/acid/spilo-14:2.1-p6"
+              enable_crd_registration:
+                type: boolean
+                default: true
               enable_crd_validation:
                 type: boolean
+                description: deprecated
                 default: true
               enable_lazy_spilo_upgrade:
                 type: boolean
@@ -84,16 +91,20 @@ spec:
               etcd_host:
                 type: string
                 default: ""
+              ignore_instance_limits_annotation_key:
+                type: string
               kubernetes_use_configmaps:
                 type: boolean
                 default: false
               max_instances:
                 type: integer
-                minimum: -1  # -1 = disabled
+                description: "-1 = disabled"
+                minimum: -1
                 default: -1
               min_instances:
                 type: integer
-                minimum: -1  # -1 = disabled
+                description: "-1 = disabled"
+                minimum: -1
                 default: -1
               resync_period:
                 type: string
@@ -121,6 +132,20 @@ spec:
               users:
                 type: object
                 properties:
+                  additional_owner_roles:
+                    type: array
+                    nullable: true
+                    items:
+                      type: string
+                  enable_password_rotation:
+                    type: boolean
+                    default: false
+                  password_rotation_interval:
+                    type: integer
+                    default: 90
+                  password_rotation_user_retention:
+                    type: integer
+                    default: 180
                   replication_username:
                      type: string
                      default: standby
@@ -133,12 +158,16 @@ spec:
                   major_version_upgrade_mode:
                     type: string
                     default: "off"
+                  major_version_upgrade_team_allow_list:
+                    type: array
+                    items:
+                      type: string
                   minimal_major_version:
                     type: string
-                    default: "9.5"
+                    default: "9.6"
                   target_major_version:
                     type: string
-                    default: "13"
+                    default: "14"
               kubernetes:
                 type: object
                 properties:
@@ -170,6 +199,9 @@ spec:
                     type: array
                     items:
                       type: string
+                  enable_cross_namespace_secret:
+                    type: boolean
+                    default: false
                   enable_init_containers:
                     type: boolean
                     default: true
@@ -182,6 +214,10 @@ spec:
                   enable_sidecars:
                     type: boolean
                     default: true
+                  ignored_annotations:
+                    type: array
+                    items:
+                      type: string
                   infrastructure_roles_secret_name:
                     type: string
                   infrastructure_roles_secrets:
@@ -218,6 +254,139 @@ spec:
                     type: array
                     items:
                       type: string
+                  liveness_probe:
+                    description: Probe describes a health check to be performed against
+                      a container to determine whether it is alive or ready to receive
+                      traffic.
+                    properties:
+                      exec:
+                        description: One and only one of the following should be specified.
+                          Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Name or number of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness and startup. Minimum value is
+                          1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: 'TCPSocket specifies an action involving a TCP
+                          port. TCP hooks not yet supported TODO: implement a realistic
+                          TCP lifecycle hook'
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Number or name of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: Optional duration in seconds the pod needs to
+                          terminate gracefully upon probe failure. The grace period
+                          is the duration in seconds after the processes running in
+                          the pod are sent a termination signal and the time when
+                          the processes are forcibly halted with a kill signal. Set
+                          this value longer than the expected cleanup time for your
+                          process. If this value is nil, the pod's terminationGracePeriodSeconds
+                          will be used. Otherwise, this value overrides the value
+                          provided by the pod spec. Value must be non-negative integer.
+                          The value zero indicates stop immediately via the kill signal
+                          (no opportunity to shut down). This is a beta field and
+                          requires enabling ProbeTerminationGracePeriod feature gate.
+                          Minimum value is 1. spec.terminationGracePeriodSeconds is
+                          used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                    type: object
                   master_pod_move_timeout:
                     type: string
                     default: "20m"
@@ -225,6 +394,11 @@ spec:
                     type: object
                     additionalProperties:
                       type: string
+                  node_readiness_label_merge:
+                    type: string
+                    enum:
+                      - "AND"
+                      - "OR"
                   oauth_token_secret_name:
                     type: string
                     default: "postgresql-operator"
@@ -280,6 +454,7 @@ spec:
                     type: string
                     enum:
                       - "ebs"
+                      - "mixed"
                       - "pvc"
                       - "off"
                     default: "pvc"
@@ -319,6 +494,12 @@ spec:
               timeouts:
                 type: object
                 properties:
+                  patroni_api_check_interval:
+                    type: string
+                    default: "1s"
+                  patroni_api_check_timeout:
+                    type: string
+                    default: "5s"
                   pod_label_wait_timeout:
                     type: string
                     default: "10m"
@@ -350,7 +531,13 @@ spec:
                   enable_master_load_balancer:
                     type: boolean
                     default: true
+                  enable_master_pooler_load_balancer:
+                    type: boolean
+                    default: false
                   enable_replica_load_balancer:
+                    type: boolean
+                    default: false
+                  enable_replica_pooler_load_balancer:
                     type: boolean
                     default: false
                   external_traffic_policy:
@@ -388,6 +575,8 @@ spec:
                     type: string
                   log_s3_bucket:
                     type: string
+                  wal_az_storage_account:
+                    type: string
                   wal_gs_bucket:
                     type: string
                   wal_s3_bucket:
@@ -397,7 +586,7 @@ spec:
                 properties:
                   logical_backup_docker_image:
                     type: string
-                    default: "registry.opensource.zalan.do/acid/logical-backup:v1.6.3"
+                    default: "registry.opensource.zalan.do/acid/logical-backup:v1.8.2"
                   logical_backup_google_application_credentials:
                     type: string
                   logical_backup_job_prefix:
@@ -417,6 +606,8 @@ spec:
                   logical_backup_s3_secret_access_key:
                     type: string
                   logical_backup_s3_sse:
+                    type: string
+                  logical_backup_s3_retention_time:
                     type: string
                   logical_backup_schedule:
                     type: string
@@ -468,6 +659,7 @@ spec:
                       type: string
                     default:
                     - admin
+                    - cron_admin
                   role_deletion_suffix:
                     type: string
                     default: "_deleted"
@@ -532,7 +724,7 @@ spec:
                     default: "pooler"
                   connection_pooler_image:
                     type: string
-                    default: "registry.opensource.zalan.do/acid/pgbouncer:master-16"
+                    default: "registry.opensource.zalan.do/acid/pgbouncer:master-22"
                   connection_pooler_max_db_connections:
                     type: integer
                     default: 60

--- a/postgres/helm/postgres/crds/postgresqls.yaml
+++ b/postgres/helm/postgres/crds/postgresqls.yaml
@@ -4,8 +4,6 @@ metadata:
   name: postgresqls.acid.zalan.do
   labels:
     app.kubernetes.io/name: postgres-operator
-  annotations:
-    "helm.sh/hook": crd-install
 spec:
   group: acid.zalan.do
   names:
@@ -149,18 +147,12 @@ spec:
                       - "transaction"
                   numberOfInstances:
                     type: integer
-                    minimum: 2
+                    minimum: 1
                   resources:
                     type: object
-                    required:
-                      - requests
-                      - limits
                     properties:
                       limits:
                         type: object
-                        required:
-                          - cpu
-                          - memory
                         properties:
                           cpu:
                             type: string
@@ -170,9 +162,6 @@ spec:
                             pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
                       requests:
                         type: object
-                        required:
-                          - cpu
-                          - memory
                         properties:
                           cpu:
                             type: string
@@ -199,12 +188,157 @@ spec:
                 type: boolean
               enableMasterLoadBalancer:
                 type: boolean
+              enableMasterPoolerLoadBalancer:
+                type: boolean
               enableReplicaLoadBalancer:
+                type: boolean
+              enableReplicaPoolerLoadBalancer:
                 type: boolean
               enableShmVolume:
                 type: boolean
-              init_containers:  # deprecated
+              env:
                 type: array
+                nullable: true
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              livenessProbe:
+                description: 'Periodic probe of container liveness. Container
+                  will be restarted if the probe fails. Cannot be updated. More
+                  info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                properties:
+                  exec:
+                    description: One and only one of the following should be
+                      specified. Exec specifies the action to take.
+                    properties:
+                      command:
+                        description: Command is the command line to execute
+                          inside the container, the working directory for the
+                          command  is root ('/') in the container's filesystem.
+                          The command is simply exec'd, it is not run inside
+                          a shell, so traditional shell instructions ('|', etc)
+                          won't work. To use a shell, you need to explicitly
+                          call out to that shell. Exit status of 0 is treated
+                          as live/healthy and non-zero is unhealthy.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  failureThreshold:
+                    description: Minimum consecutive failures for the probe
+                      to be considered failed after having succeeded. Defaults
+                      to 3. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  httpGet:
+                    description: HTTPGet specifies the http request to perform.
+                    properties:
+                      host:
+                        description: Host name to connect to, defaults to the
+                          pod IP. You probably want to set "Host" in httpHeaders
+                          instead.
+                        type: string
+                      httpHeaders:
+                        description: Custom headers to set in the request. HTTP
+                          allows repeated headers.
+                        items:
+                          description: HTTPHeader describes a custom header
+                            to be used in HTTP probes
+                          properties:
+                            name:
+                              description: The header field name
+                              type: string
+                            value:
+                              description: The header field value
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      path:
+                        description: Path to access on the HTTP server.
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Name or number of the port to access on
+                          the container. Number must be in the range 1 to 65535.
+                          Name must be an IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                      scheme:
+                        description: Scheme to use for connecting to the host.
+                          Defaults to HTTP.
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  initialDelaySeconds:
+                    description: 'Number of seconds after the container has
+                      started before liveness probes are initiated. More info:
+                      https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                    format: int32
+                    type: integer
+                  periodSeconds:
+                    description: How often (in seconds) to perform the probe.
+                      Default to 10 seconds. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  successThreshold:
+                    description: Minimum consecutive successes for the probe
+                      to be considered successful after having failed. Defaults
+                      to 1. Must be 1 for liveness and startup. Minimum value
+                      is 1.
+                    format: int32
+                    type: integer
+                  tcpSocket:
+                    description: 'TCPSocket specifies an action involving a
+                      TCP port. TCP hooks not yet supported TODO: implement
+                      a realistic TCP lifecycle hook'
+                    properties:
+                      host:
+                        description: 'Optional: Host name to connect to, defaults
+                          to the pod IP.'
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Number or name of the port to access on
+                          the container. Number must be in the range 1 to 65535.
+                          Name must be an IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - port
+                    type: object
+                  terminationGracePeriodSeconds:
+                    description: Optional duration in seconds the pod needs
+                      to terminate gracefully upon probe failure. The grace
+                      period is the duration in seconds after the processes
+                      running in the pod are sent a termination signal and the
+                      time when the processes are forcibly halted with a kill
+                      signal. Set this value longer than the expected cleanup
+                      time for your process. If this value is nil, the pod's
+                      terminationGracePeriodSeconds will be used. Otherwise,
+                      this value overrides the value provided by the pod spec.
+                      Value must be non-negative integer. The value zero indicates
+                      stop immediately via the kill signal (no opportunity to
+                      shut down). This is a beta field and requires enabling
+                      ProbeTerminationGracePeriod feature gate. Minimum value
+                      is 1. spec.terminationGracePeriodSeconds is used if unset.
+                    format: int64
+                    type: integer
+                  timeoutSeconds:
+                    description: 'Number of seconds after which the probe times
+                      out. Defaults to 1 second. Minimum value is 1. More info:
+                      https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                    format: int32
+                    type: integer
+                type: object
+              init_containers:
+                type: array
+                description: deprecated
                 nullable: true
                 items:
                   type: object
@@ -223,179 +357,6 @@ spec:
                 items:
                   type: string
                   pattern: '^\ *((Mon|Tue|Wed|Thu|Fri|Sat|Sun):(2[0-3]|[01]?\d):([0-5]?\d)|(2[0-3]|[01]?\d):([0-5]?\d))-((Mon|Tue|Wed|Thu|Fri|Sat|Sun):(2[0-3]|[01]?\d):([0-5]?\d)|(2[0-3]|[01]?\d):([0-5]?\d))\ *$'
-              numberOfInstances:
-                type: integer
-                minimum: 0
-              patroni:
-                type: object
-                properties:
-                  initdb:
-                    type: object
-                    additionalProperties:
-                      type: string
-                  loop_wait:
-                    type: integer
-                  maximum_lag_on_failover:
-                    type: integer
-                  pg_hba:
-                    type: array
-                    items:
-                      type: string
-                  retry_timeout:
-                    type: integer
-                  slots:
-                    type: object
-                    additionalProperties:
-                      type: object
-                      additionalProperties:
-                        type: string
-                  synchronous_mode:
-                    type: boolean
-                  synchronous_mode_strict:
-                    type: boolean
-                  ttl:
-                    type: integer
-              podAnnotations:
-                type: object
-                additionalProperties:
-                  type: string
-              pod_priority_class_name:  # deprecated
-                type: string
-              podPriorityClassName:
-                type: string
-              postgresql:
-                type: object
-                required:
-                  - version
-                properties:
-                  version:
-                    type: string
-                    enum:
-                      - "9.3"
-                      - "9.4"
-                      - "9.5"
-                      - "9.6"
-                      - "10"
-                      - "11"
-                      - "12"
-                      - "13"
-                  parameters:
-                    type: object
-                    additionalProperties:
-                      type: string
-              preparedDatabases:
-                type: object
-                additionalProperties:
-                  type: object
-                  properties:
-                    defaultUsers:
-                      type: boolean
-                    extensions:
-                      type: object
-                      additionalProperties:
-                        type: string
-                    schemas:
-                      type: object
-                      additionalProperties:
-                        type: object
-                        properties:
-                          defaultUsers:
-                            type: boolean
-                          defaultRoles:
-                            type: boolean
-              replicaLoadBalancer:  # deprecated
-                type: boolean
-              resources:
-                type: object
-                required:
-                  - requests
-                  - limits
-                properties:
-                  limits:
-                    type: object
-                    required:
-                      - cpu
-                      - memory
-                    properties:
-                      cpu:
-                        type: string
-                        # Decimal natural followed by m, or decimal natural followed by
-                        # dot followed by up to three decimal digits.
-                        #
-                        # This is because the Kubernetes CPU resource has millis as the
-                        # maximum precision.  The actual values are checked in code
-                        # because the regular expression would be huge and horrible and
-                        # not very helpful in validation error messages; this one checks
-                        # only the format of the given number.
-                        #
-                        # https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-cpu
-                        pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
-                        # Note: the value specified here must not be zero or be lower
-                        # than the corresponding request.
-                      memory:
-                        type: string
-                        # You can express memory as a plain integer or as a fixed-point
-                        # integer using one of these suffixes: E, P, T, G, M, k. You can
-                        # also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki
-                        #
-                        # https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory
-                        pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
-                        # Note: the value specified here must not be zero or be higher
-                        # than the corresponding limit.
-                  requests:
-                    type: object
-                    required:
-                      - cpu
-                      - memory
-                    properties:
-                      cpu:
-                        type: string
-                        pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
-                      memory:
-                        type: string
-                        pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
-              schedulerName:
-                type: string
-              serviceAnnotations:
-                type: object
-                additionalProperties:
-                  type: string
-              sidecars:
-                type: array
-                nullable: true
-                items:
-                  type: object
-                  x-kubernetes-preserve-unknown-fields: true
-              spiloRunAsUser:
-                type: integer
-              spiloRunAsGroup:
-                type: integer
-              spiloFSGroup:
-                type: integer
-              standby:
-                type: object
-                required:
-                  - s3_wal_path
-                properties:
-                  s3_wal_path:
-                    type: string
-              teamId:
-                type: string
-              tls:
-                type: object
-                required:
-                  - secretName
-                properties:
-                  secretName:
-                    type: string
-                  certificateFile:
-                    type: string
-                  privateKeyFile:
-                    type: string
-                  caFile:
-                    type: string
-                  caSecretName:
-                    type: string
               nodeAffinity:
                 type: object
                 properties:
@@ -404,8 +365,8 @@ spec:
                     items:
                       type: object
                       required:
-                      - weight
                       - preference
+                      - weight
                       properties:
                         preference:
                           type: object
@@ -487,14 +448,222 @@ spec:
                                     type: array
                                     items:
                                       type: string
-              tolerations:
+              numberOfInstances:
+                type: integer
+                minimum: 0
+              patroni:
+                type: object
+                properties:
+                  initdb:
+                    type: object
+                    additionalProperties:
+                      type: string
+                  loop_wait:
+                    type: integer
+                  maximum_lag_on_failover:
+                    type: integer
+                  pg_hba:
+                    type: array
+                    items:
+                      type: string
+                  retry_timeout:
+                    type: integer
+                  slots:
+                    type: object
+                    additionalProperties:
+                      type: object
+                      additionalProperties:
+                        type: string
+                  synchronous_mode:
+                    type: boolean
+                  synchronous_mode_strict:
+                    type: boolean
+                  synchronous_node_count:
+                    type: integer
+                  ttl:
+                    type: integer
+              podAnnotations:
+                type: object
+                additionalProperties:
+                  type: string
+              pod_priority_class_name:
+                type: string
+                description: deprecated
+              podPriorityClassName:
+                type: string
+              postgresql:
+                type: object
+                required:
+                  - version
+                properties:
+                  version:
+                    type: string
+                    enum:
+                      - "9.5"
+                      - "9.6"
+                      - "10"
+                      - "11"
+                      - "12"
+                      - "13"
+                      - "14"
+                  parameters:
+                    type: object
+                    additionalProperties:
+                      type: string
+              preparedDatabases:
+                type: object
+                additionalProperties:
+                  type: object
+                  properties:
+                    defaultUsers:
+                      type: boolean
+                    extensions:
+                      type: object
+                      additionalProperties:
+                        type: string
+                    schemas:
+                      type: object
+                      additionalProperties:
+                        type: object
+                        properties:
+                          defaultUsers:
+                            type: boolean
+                          defaultRoles:
+                            type: boolean
+                    secretNamespace:
+                      type: string
+              replicaLoadBalancer:
+                type: boolean
+                description: deprecated
+              resources:
+                type: object
+                properties:
+                  limits:
+                    type: object
+                    properties:
+                      cpu:
+                        type: string
+                        # Decimal natural followed by m, or decimal natural followed by
+                        # dot followed by up to three decimal digits.
+                        #
+                        # This is because the Kubernetes CPU resource has millis as the
+                        # maximum precision.  The actual values are checked in code
+                        # because the regular expression would be huge and horrible and
+                        # not very helpful in validation error messages; this one checks
+                        # only the format of the given number.
+                        #
+                        # https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-cpu
+                        pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
+                        # Note: the value specified here must not be zero or be lower
+                        # than the corresponding request.
+                      memory:
+                        type: string
+                        # You can express memory as a plain integer or as a fixed-point
+                        # integer using one of these suffixes: E, P, T, G, M, k. You can
+                        # also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki
+                        #
+                        # https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory
+                        pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
+                        # Note: the value specified here must not be zero or be higher
+                        # than the corresponding limit.
+                  requests:
+                    type: object
+                    properties:
+                      cpu:
+                        type: string
+                        pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
+                      memory:
+                        type: string
+                        pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
+              schedulerName:
+                type: string
+              serviceAnnotations:
+                type: object
+                additionalProperties:
+                  type: string
+              sidecars:
+                type: array
+                nullable: true
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              spiloRunAsUser:
+                type: integer
+              spiloRunAsGroup:
+                type: integer
+              spiloFSGroup:
+                type: integer
+              standby:
+                type: object
+                properties:
+                  s3_wal_path:
+                    type: string
+                  gs_wal_path:
+                    type: string
+                  standby_host:
+                    type: string
+                  standby_port:
+                    type: string
+                oneOf:
+                - required:
+                  - s3_wal_path
+                - required:
+                  - gs_wal_path
+                - required:
+                  - standby_host
+              streams:
                 type: array
                 items:
                   type: object
                   required:
-                    - key
-                    - operator
-                    - effect
+                    - applicationId
+                    - database
+                    - tables
+                  properties:
+                    applicationId:
+                      type: string
+                    batchSize:
+                      type: integer
+                    database:
+                      type: string
+                    filter:
+                      type: object
+                      additionalProperties:
+                        type: string
+                    tables:
+                      type: object
+                      additionalProperties:
+                        type: object
+                        required:
+                          - eventType
+                        properties:
+                          eventType:
+                            type: string
+                          idColumn:
+                            type: string
+                          payloadColumn:
+                            type: string
+              teamId:
+                type: string
+              tls:
+                type: object
+                required:
+                  - secretName
+                properties:
+                  secretName:
+                    type: string
+                  certificateFile:
+                    type: string
+                  privateKeyFile:
+                    type: string
+                  caFile:
+                    type: string
+                  caSecretName:
+                    type: string
+              tolerations:
+                type: array
+                items:
+                  type: object
                   properties:
                     key:
                       type: string
@@ -513,14 +682,14 @@ spec:
                         - PreferNoSchedule
                     tolerationSeconds:
                       type: integer
-              useLoadBalancer:  # deprecated
+              useLoadBalancer:
                 type: boolean
+                description: deprecated
               users:
                 type: object
                 additionalProperties:
                   type: array
                   nullable: true
-                  description: "Role flags specified here must not contradict each other"
                   items:
                     type: string
                     enum:
@@ -552,6 +721,16 @@ spec:
                     - SUPERUSER
                     - nosuperuser
                     - NOSUPERUSER
+              usersWithInPlaceSecretRotation:
+                type: array
+                nullable: true
+                items:
+                  type: string
+              usersWithSecretRotation:
+                type: array
+                nullable: true
+                items:
+                  type: string
               volume:
                 type: object
                 required:
@@ -559,6 +738,33 @@ spec:
                 properties:
                   iops:
                     type: integer
+                  selector:
+                    type: object
+                    properties:
+                      matchExpressions:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - key
+                            - operator
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                              enum:
+                                - DoesNotExist
+                                - Exists
+                                - In
+                                - NotIn
+                            values:
+                              type: array
+                              items:
+                                type: string
+                      matchLabels:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                   size:
                     type: string
                     pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'

--- a/postgres/helm/postgres/crds/postgresteams.yaml
+++ b/postgres/helm/postgres/crds/postgresteams.yaml
@@ -4,8 +4,6 @@ metadata:
   name: postgresteams.acid.zalan.do
   labels:
     app.kubernetes.io/name: postgres-operator
-  annotations:
-    "helm.sh/hook": crd-install
 spec:
   group: acid.zalan.do
   names:

--- a/postgres/helm/postgres/values.yaml
+++ b/postgres/helm/postgres/values.yaml
@@ -10,7 +10,7 @@ oauthSecretName: postgres-operator
 image:
   registry: dkr.plural.sh
   repository: postgres/acid/postgres-operator
-  tag: v1.8.2-6-g8c94e377-dirty
+  tag: v1.8.2-7-g73a0dfee-dirty
   pullPolicy: "IfNotPresent"
 
   # Optionally specify an array of imagePullSecrets.

--- a/postgres/helm/postgres/values.yaml
+++ b/postgres/helm/postgres/values.yaml
@@ -8,9 +8,9 @@ operatorConfigName: operator-configuration
 oauthSecretName: postgres-operator
 
 image:
-  registry: registry.opensource.zalan.do
-  repository: acid/postgres-operator
-  tag: v1.6.3
+  registry: dkr.plural.sh
+  repository: postgres/acid/postgres-operator
+  tag: v1.8.2-6-g8c94e377-dirty
   pullPolicy: "IfNotPresent"
 
   # Optionally specify an array of imagePullSecrets.
@@ -150,8 +150,6 @@ configKubernetes:
   # label assigned to the Postgres pods (and services/endpoints)
   pod_role_label: spilo-role
 
-  pod_service_account_name: postgres-pod
-
   # service account definition as JSON/YAML string to be used by postgres cluster pods
   # pod_service_account_definition: ""
 
@@ -177,6 +175,17 @@ configKubernetes:
   storage_resize_mode: pvc
   # operator watches for postgres objects in the given namespace
   watched_namespace: "*"  # listen to all namespaces
+
+  liveness_probe:
+    failureThreshold: 3
+    httpGet:
+      path: /readiness
+      port: 8008
+      scheme: HTTP
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 5
 
 configSecret:
   enabled: false

--- a/postgres/helm/postgres/values.yaml
+++ b/postgres/helm/postgres/values.yaml
@@ -44,7 +44,7 @@ configGeneral:
   # Select if setup uses endpoints (default), or configmaps to manage leader (DCS=k8s)
   # kubernetes_use_configmaps: false
   # Spilo docker image
-  docker_image: "dkr.plural.sh/postgres/acid/spilo-14:2.1-p6"
+  docker_image: "ghcr.io/pluralsh/spilo-14:2.1-p7"
   # min number of instances in Postgres cluster. -1 = no limit
   min_instances: -1
   # max number of instances in Postgres cluster. -1 = no limit

--- a/postgres/helm/postgres/values.yaml
+++ b/postgres/helm/postgres/values.yaml
@@ -44,7 +44,7 @@ configGeneral:
   # Select if setup uses endpoints (default), or configmaps to manage leader (DCS=k8s)
   # kubernetes_use_configmaps: false
   # Spilo docker image
-  docker_image: registry.opensource.zalan.do/acid/spilo-14:2.1-p6
+  docker_image: "dkr.plural.sh/postgres/acid/spilo-14:2.1-p6"
   # min number of instances in Postgres cluster. -1 = no limit
   min_instances: -1
   # max number of instances in Postgres cluster. -1 = no limit
@@ -295,7 +295,7 @@ configAwsOrGcp:
 # configure K8s cron job managed by the operator
 configLogicalBackup:
   # image for pods of the logical backup job (example runs pg_dumpall)
-  logical_backup_docker_image: "registry.opensource.zalan.do/acid/logical-backup:v1.8.2"
+  logical_backup_docker_image: "dkr.plural.sh/postgres/acid/logical-backup:v1.8.2"
   # path of google cloud service account json file
   # logical_backup_google_application_credentials: ""
 
@@ -360,7 +360,7 @@ configConnectionPooler:
   # db user for pooler to use
   connection_pooler_user: "pooler"
   # docker image
-  connection_pooler_image: "registry.opensource.zalan.do/acid/pgbouncer:master-16"
+  connection_pooler_image: "dkr.plural.sh/postgres/acid/pgbouncer:master-24"
   # max db connections the pooler should hold
   connection_pooler_max_db_connections: 60
   # default pooling mode

--- a/postgres/helm/postgres/values.yaml
+++ b/postgres/helm/postgres/values.yaml
@@ -44,7 +44,7 @@ configGeneral:
   # Select if setup uses endpoints (default), or configmaps to manage leader (DCS=k8s)
   # kubernetes_use_configmaps: false
   # Spilo docker image
-  docker_image: gcr.io/pluralsh/spilo:13.3
+  docker_image: registry.opensource.zalan.do/acid/spilo-14:2.1-p6
   # min number of instances in Postgres cluster. -1 = no limit
   min_instances: -1
   # max number of instances in Postgres cluster. -1 = no limit

--- a/postgres/helm/postgres/values.yaml
+++ b/postgres/helm/postgres/values.yaml
@@ -395,7 +395,6 @@ podServiceAccount:
   # The name of the ServiceAccount to be used by postgres cluster pods
   # If not set a name is generated using the fullname template and "-pod" suffix
   name: "postgres-pod"
-  annotations: {}
 
 # priority class for operator pod
 priorityClassName: "postgres"

--- a/postgres/helm/postgres/values.yaml
+++ b/postgres/helm/postgres/values.yaml
@@ -295,7 +295,7 @@ configAwsOrGcp:
 # configure K8s cron job managed by the operator
 configLogicalBackup:
   # image for pods of the logical backup job (example runs pg_dumpall)
-  logical_backup_docker_image: "registry.opensource.zalan.do/acid/logical-backup:v1.6.3"
+  logical_backup_docker_image: "registry.opensource.zalan.do/acid/logical-backup:v1.8.2"
   # path of google cloud service account json file
   # logical_backup_google_application_credentials: ""
 

--- a/postgres/helm/postgres/values.yaml
+++ b/postgres/helm/postgres/values.yaml
@@ -74,9 +74,9 @@ configMajorVersionUpgrade:
   # "off": no upgrade, "manual": manifest triggers action, "full": minimal version violation triggers too
   major_version_upgrade_mode: "off"
   # minimal Postgres major version that will not automatically be upgraded
-  minimal_major_version: "9.5"
+  minimal_major_version: "9.6"
   # target Postgres major version when upgrading clusters automatically
-  target_major_version: "13"
+  target_major_version: "14"
 
 configKubernetes:
   # list of additional capabilities for postgres container

--- a/postgres/helm/postgres/values.yaml
+++ b/postgres/helm/postgres/values.yaml
@@ -44,7 +44,7 @@ configGeneral:
   # Select if setup uses endpoints (default), or configmaps to manage leader (DCS=k8s)
   # kubernetes_use_configmaps: false
   # Spilo docker image
-  docker_image: "ghcr.io/pluralsh/spilo-14:2.1-p7"
+  docker_image: "dkr.plural.sh/postgres/acid/spilo-14:2.1-p7"
   # min number of instances in Postgres cluster. -1 = no limit
   min_instances: -1
   # max number of instances in Postgres cluster. -1 = no limit

--- a/postgres/helm/postgres/values.yaml.tpl
+++ b/postgres/helm/postgres/values.yaml.tpl
@@ -42,6 +42,16 @@ configKubernetes:
   pod_environment_secret: plural-postgres-s3
 {{ end }}
 
+{{- if eq .Provider "aws" }}
+configKubernetes:
+  pod_service_account_definition: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      annotations:
+        eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Project }}:role/{{ .Cluster }}-postgres"
+{{- end }}
+
 {{ if or (eq .Provider "azure") (eq .Provider "equinix") (eq .Provider "kind") }}
 configSecret:
   enabled: true


### PR DESCRIPTION
## Summary
This PR updates the postgres operator to the latest version along with a modification that allows for setting liveness probes for databases. This should fix issues where patroni can't talk to the Kubernetes API anymore. It also uses a newer Spilo image that fixes the backup retention policy which wasn't working. Another small fix is that the operator will now add the necessary annotation for IRSA to service accounts it creates for the postgres pods (so this doesn't need to be done with terraform anymore).

## Test Plan
Local linking. 
- Check that backups are pushed to S3.
- Check that WAL archives are pushed to S3.
- Check that old backups are cleaned up.
- Check that there aren't any errors in the `pg_log` logs (related to send WAL archives to S3)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP