### PR TITLE
Operator oauth sidecar reloading

### DIFF
--- a/bootstrap/helm/bootstrap/Chart.yaml
+++ b/bootstrap/helm/bootstrap/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   email: mguarino46@gmail.com
 - name: David van der Spek
   email: david@plural.sh
-version: 0.8.52
+version: 0.8.53
 dependencies:
 - name: external-dns
   version: 4.11.0

--- a/bootstrap/helm/bootstrap/templates/configmap.yaml
+++ b/bootstrap/helm/bootstrap/templates/configmap.yaml
@@ -6,7 +6,7 @@ data:
   oauth-sidecar-config.yaml: |
     containers:
     - name: oauth2-proxy
-      image: quay.io/oauth2-proxy/oauth2-proxy:v7.2.0
+      image: dkr.plural.sh/oauth2-proxy/oauth2-proxy/oauth2-proxy:v7.3.0
       imagePullPolicy: IfNotPresent
       resources:
         requests:

--- a/bootstrap/helm/bootstrap/templates/operator.yaml
+++ b/bootstrap/helm/bootstrap/templates/operator.yaml
@@ -23,12 +23,19 @@ spec:
         - /manager
         args:
         - --leader-elect
-        - --oauth-sidecar-config-path=/tmp/k8s-webhook-server/config/oauth-sidecar-config.yaml
         image: "{{ .Values.plural.image.repository }}:{{ .Values.plural.image.tag }}"
         imagePullPolicy: Always
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+        env:
+        - name: PLURAL_OAUTH_SIDECAR_CONFIG_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: PLURAL_OAUTH_SIDECAR_CONFIG_NAME
+          value: plural-operator-oauth-sidecar-config
         ports:
         - containerPort: 8081
           name: health
@@ -59,15 +66,10 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: webhook-cert
           readOnly: true
-        - mountPath: /tmp/k8s-webhook-server/config
-          name: sidecar-config
       volumes:
       - name: webhook-cert
         secret:
           defaultMode: 420
           secretName: plural-operator-webhook-server-cert
-      - configMap:
-          name: plural-operator-oauth-sidecar-config
-        name: sidecar-config
       serviceAccountName: plural-operator
       terminationGracePeriodSeconds: 10

--- a/bootstrap/helm/bootstrap/templates/rbac.yaml
+++ b/bootstrap/helm/bootstrap/templates/rbac.yaml
@@ -84,6 +84,15 @@ rules:
   - update
   - patch
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
   - batch
   resources:
   - jobs

--- a/bootstrap/helm/bootstrap/values.yaml
+++ b/bootstrap/helm/bootstrap/values.yaml
@@ -35,7 +35,7 @@ pluralToken: plrl-api-token
 plural:
   image:
     repository: dkr.plural.sh/bootstrap/plural-operator
-    tag: v0.3.4
+    tag: 0.4.0
 
 imagePullSecrets:
 - name: plural-creds


### PR DESCRIPTION
## Summary
This PR updates the Plural operator which includes the new global pull credentials and the ability to restart pods that have an Oauth2-Proxy sidecar injected when either the sidecar configmap or secrets change.


## Test Plan
Local linking. Testing by changing either the global oauth-proxy configmap or the oauth2-proxy secret from which the environment variables are loaded.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP