### PR TITLE
Add airbyte metrics exporter

### DIFF
--- a/airbyte/helm/airbyte/Chart.yaml
+++ b/airbyte/helm/airbyte/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: airbyte
 description: Unified data integration platform
 type: application
-version: 0.2.25
+version: 0.2.26
 appVersion: 0.39.14-alpha
 dependencies:
   - name: airbyte

--- a/airbyte/helm/airbyte/templates/_helpers.tpl
+++ b/airbyte/helm/airbyte/templates/_helpers.tpl
@@ -60,3 +60,8 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{- define "airbyte-plural.database.url" -}}
+{{- $db := .Values.airbyte.externalDatabase -}}
+{{- printf "jdbc:postgresql://%s:5432/%s" $db.host $db.database -}}
+{{- end -}}

--- a/airbyte/helm/airbyte/templates/metrics.yaml
+++ b/airbyte/helm/airbyte/templates/metrics.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-metrics
+  labels:
+  {{ include "airbyte.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      airbyte.component: metrics
+      app: airbyte-metrics
+  template:
+    metadata:
+      labels:
+        airbyte.component: metrics
+        app: airbyte-metrics
+        {{ include "airbyte.labels" . | nindent 8 }}
+    spec:
+      containers:
+      - name: airbyte-metrics
+        image: "{{ .Values.global.imageRegistry }}/airbyte/metrics-reporter:{{ .Values.airbyte.version }}"
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: AIRBYTE_VERSION
+          value: {{ .Values.airbyte.version }}
+        - name: DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.airbyte.externalDatabase.existingSecret }}
+              key: {{ .Values.airbyte.externalDatabase.existingSecretPasswordKey }}
+        - name: DATABASE_URL
+          value: {{ include "airbyte-plural.database.url" . | quote }}
+        - name: DATABASE_USER
+          value: {{ .Values.airbyte.externalDatabase.user }}
+        - name: CONFIGS_DATABASE_MINIMUM_FLYWAY_MIGRATION_VERSION
+          value: 0.35.15.001
+        - name: METRIC_CLIENT
+          value: otel
+        - name: OTEL_COLLECTOR_ENDPOINT
+          value: http://plural-otel-collector.monitoring:4317

--- a/airbyte/helm/airbyte/templates/prometheusrule.yaml
+++ b/airbyte/helm/airbyte/templates/prometheusrule.yaml
@@ -37,4 +37,26 @@ spec:
       annotations:
         summary: airbyte db's memory has gotten too high
         description: the memory utilization of your plural airbyte db is higher than recommended
+---
 {{- end }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: airbyte-rules
+  namespace: {{ .Release.Namespace }}
+  labels:
+    prometheus: example
+    role: alert-rules
+spec:
+  groups:
+  - name: airbyte
+    rules:
+    - alert: AirbyteJobFail
+      for: 0m
+      expr: min(airbyte_job_failed_by_release_stage) > 0
+      labels:
+        severity: warning
+        namespace: {{ .Release.Namespace }}
+      annotations:
+        summary: an airbyte job has failed
+        description: try finding the job in the airbyte ui and manually restarting it

--- a/airbyte/helm/airbyte/values.yaml
+++ b/airbyte/helm/airbyte/values.yaml
@@ -199,6 +199,7 @@ airbyte:
     existingSecret: airbyte.plural-airbyte.credentials.postgresql.acid.zalan.do
     existingSecretPasswordKey: password
     user: airbyte
+    port: 5432
 
   bootloader:
     image:

--- a/monitoring/helm/monitoring/Chart.yaml
+++ b/monitoring/helm/monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monitoring
 description: A Helm chart for Kubernetes
 type: application
-version: 0.2.17
+version: 0.2.18
 appVersion: "0.1.0"
 dependencies:
 - name: kube-prometheus-stack

--- a/monitoring/helm/monitoring/templates/opentelemetry-collector.yaml
+++ b/monitoring/helm/monitoring/templates/opentelemetry-collector.yaml
@@ -18,6 +18,10 @@ spec:
         endpoint: "0.0.0.0:55678"
       zipkin:
         endpoint: "0.0.0.0:9411"
+      otlp:
+        protocols:
+          grpc:
+            endpoint: "0.0.0.0:4317"
 
     exporters:
       logging:
@@ -44,7 +48,7 @@ spec:
           processors: [batch]
           exporters: [otlp]
         metrics:
-          receivers: [opencensus]
+          receivers: [opencensus, otlp]
           processors: [batch]
           exporters: [prometheus]
 {{- end }}

--- a/monitoring/helm/monitoring/values.yaml
+++ b/monitoring/helm/monitoring/values.yaml
@@ -292,7 +292,7 @@ opentelemetry-operator:
       repository: dkr.plural.sh/monitoring/kubebuilder/kube-rbac-proxy
       tag: v0.8.0
   collector:
-    enabled: false
+    enabled: true
     image:
       repository: dkr.plural.sh/monitoring/otel/opentelemetry-collector
       tag: 0.59.0


### PR DESCRIPTION
## Summary

Configures the otel collector to accept grpc and sets up an exporter with airbyte's prebaked image to begin shipping/alarming on airbyte metrics


## Test Plan
tested with plural link


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP