### PR TITLE
AWS: make spot node groups multi zoned

### DIFF
--- a/bootstrap/terraform/aws-bootstrap/deps.yaml
+++ b/bootstrap/terraform/aws-bootstrap/deps.yaml
@@ -2,9 +2,8 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: Creates an EKS cluster and prepares it for bootstrapping
-  version: 0.1.41
+  version: 0.1.42
 spec:
-  breaking: true
   dependencies: []
   providers:
   - aws

--- a/bootstrap/terraform/aws-bootstrap/variables.tf
+++ b/bootstrap/terraform/aws-bootstrap/variables.tf
@@ -140,6 +140,33 @@ variable "single_az_node_groups" {
         "plural.sh/scalingGroup" = "small-burst-on-demand"
       }
     }
+    medium_burst_on_demand = {
+      name = "medium-burst-on-demand"
+      instance_types = ["t3.xlarge", "t3a.xlarge"]
+      capacity_type = "ON_DEMAND"
+      k8s_labels = {
+        "plural.sh/capacityType" = "ON_DEMAND"
+        "plural.sh/performanceType" = "BURST"
+        "plural.sh/scalingGroup" = "medium-burst-on-demand"
+      }
+    }
+    large_burst_on_demand = {
+      name = "large-burst-on-demand"
+      instance_types = ["t3.2xlarge", "t3a.2xlarge"]
+      capacity_type = "ON_DEMAND"
+      k8s_labels = {
+        "plural.sh/capacityType" = "ON_DEMAND"
+        "plural.sh/performanceType" = "BURST"
+        "plural.sh/scalingGroup" = "large-burst-on-demand"
+      }
+    }
+  }
+  description = "Node groups to add to your cluster. A single managed node group will be created in each availability zone."
+}
+
+variable "multi_az_node_groups" {
+  type = any
+  default = {
     small_burst_spot = {
       name = "small-burst-spot"
       capacity_type = "SPOT"
@@ -155,16 +182,6 @@ variable "single_az_node_groups" {
         effect = "NO_SCHEDULE"
       }]
     }
-    medium_burst_on_demand = {
-      name = "medium-burst-on-demand"
-      instance_types = ["t3.xlarge", "t3a.xlarge"]
-      capacity_type = "ON_DEMAND"
-      k8s_labels = {
-        "plural.sh/capacityType" = "ON_DEMAND"
-        "plural.sh/performanceType" = "BURST"
-        "plural.sh/scalingGroup" = "medium-burst-on-demand"
-      }
-    }
     medium_burst_spot = {
       name = "medium-burst-spot"
       instance_types = ["t3.xlarge", "t3a.xlarge"]
@@ -179,16 +196,6 @@ variable "single_az_node_groups" {
         value = "SPOT"
         effect = "NO_SCHEDULE"
       }]
-    }
-    large_burst_on_demand = {
-      name = "large-burst-on-demand"
-      instance_types = ["t3.2xlarge", "t3a.2xlarge"]
-      capacity_type = "ON_DEMAND"
-      k8s_labels = {
-        "plural.sh/capacityType" = "ON_DEMAND"
-        "plural.sh/performanceType" = "BURST"
-        "plural.sh/scalingGroup" = "large-burst-on-demand"
-      }
     }
     large_burst_spot = {
       name = "large-burst-spot"
@@ -207,12 +214,6 @@ variable "single_az_node_groups" {
       }]
     }
   }
-  description = "Node groups to add to your cluster. A single managed node group will be created in each availability zone."
-}
-
-variable "multi_az_node_groups" {
-  type = any
-  default = {}
   description = "Node groups to add to your cluster. A single managed node group will be created across all availability zones."
 }
 


### PR DESCRIPTION
## Summary
Make the spot node groups we create on AWS multi-zoned to reduce the overall amount of node groups we create.

## Test Plan
Local linking.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP