### PR TITLE
Ray: add support for git-sync

### DIFF
--- a/ray/helm/kuberay-operator/Chart.yaml
+++ b/ray/helm/kuberay-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kuberay-operator
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "v0.3.0"
 dependencies:
 - name: kuberay-operator

--- a/ray/helm/kuberay-operator/values.yaml
+++ b/ray/helm/kuberay-operator/values.yaml
@@ -1,6 +1,6 @@
 kuberay-operator:
   image:
     repository: dkr.plural.sh/ray/kuberay/operator
-    tag: v0.3.0
+    tag: 2a7f0f2
 metrics:
   enabled: true

--- a/ray/helm/ray/Chart.yaml
+++ b/ray/helm/ray/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ray
 description: helm chart for ray
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: "2.0.0"
 dependencies:
 - name: oauth2-proxy

--- a/ray/helm/ray/templates/raycluster-cluster.yaml
+++ b/ray/helm/ray/templates/raycluster-cluster.yaml
@@ -2,6 +2,7 @@ apiVersion: ray.io/v1alpha1
 kind: RayCluster
 metadata:
   labels:
+    ray.io/cluster: {{ include "ray.fullname" . }}
 {{- include "ray.labels" . | nindent 4 }}
   name: {{ include "ray.fullname" . }}
 spec:
@@ -69,18 +70,66 @@ spec:
             {{- with .Values.head.container.extraPorts }}
               {{- toYaml . | nindent 14}}
             {{- end }}
+            {{- if or .Values.gitSync.enabled .Values.head.container.volumeMounts }}
+            volumeMounts:
             {{- with .Values.head.container.volumeMounts }}
-            volumeMounts: {{- toYaml . | nindent 12 }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if .Values.gitSync.enabled }}
+            - name: git-sync
+              mountPath: /home/ray/git-sync
+            {{- end }}
             {{- end }}
             {{- with .Values.head.container.lifecycle }}
             lifecycle:
             {{- toYaml . | nindent 14 }}
             {{- end }}
+          {{- if .Values.gitSync.enabled }}
+          - name: git-sync
+            image: k8s.gcr.io/git-sync/git-sync:v3.6.1
+            env:
+            - name: GIT_SYNC_REPO
+              value: {{ .Values.gitSync.repo }}
+            - name: GIT_SYNC_BRANCH
+              value: {{ .Values.gitSync.branch }}
+            - name: GIT_SYNC_ROOT
+              value: /home/ray/git-sync
+            - name: GIT_SYNC_PERIOD
+              value: {{ .Values.gitSync.period }}
+            {{- if .Values.gitSync.password }}
+            - name: GIT_SYNC_PASSWORD_FILE
+              value: /etc/git-secret/password
+            {{- end }}
+            {{- if .Values.gitSync.username }}
+            - name: GIT_SYNC_USERNAME
+              value: {{ .Values.gitSync.username }}
+            {{- end }}
+            volumeMounts:
+            - name: git-sync
+              mountPath: /home/ray/git-sync
+            {{- if .Values.gitSync.password }}
+            - name: git-sync-password
+              mountPath: /etc/git-secret/password
+              subPath: password
+            {{- end }}
+          {{- end }}
           {{- with .Values.head.extraContainers }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
+        {{- if or .Values.gitSync.enabled .Values.head.volumes }}
+        volumes:
         {{- with .Values.head.volumes }}
-        volumes: {{- toYaml . | nindent 10 }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- if .Values.gitSync.enabled }}
+          - name: git-sync
+            emptyDir: {}
+          {{- if .Values.gitSync.password }}
+          - name: git-sync-password
+            secret:
+              secretName: {{ include "ray.fullname" . }}-git-password # todo: add secret file and template name into here
+          {{- end }}
+        {{- end }}
         {{- end }}
         {{- with .Values.head.affinity}}
         affinity: {{- toYaml . | nindent 10 }}

--- a/ray/helm/ray/templates/secrets.yaml
+++ b/ray/helm/ray/templates/secrets.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.gitSync.password }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ray.fullname" . }}-git-password
+  labels:
+    {{- include "ray.labels" . | nindent 4 }}
+data:
+  password: {{ .Values.gitSync.password | b64enc }}
+{{- end }}

--- a/ray/helm/ray/values.yaml
+++ b/ray/helm/ray/values.yaml
@@ -23,6 +23,8 @@ dashboard:
       kubernetes.io/tls-acme: "true"
       cert-manager.io/cluster-issuer: letsencrypt-prod
       nginx.ingress.kubernetes.io/force-ssl-redirect: 'true'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: 256k
+      nginx.ingress.kubernetes.io/use-regex: 'false'
     hosts:
      - host: example.com
        paths:
@@ -47,6 +49,14 @@ autoscaling:
       requests:
         cpu: 500m
         memory: 512Mi
+
+gitSync:
+  enabled: false
+  repo: ""
+  branch: main
+  period: 30s
+  password: ""
+  username: ""
 
 head:
   serviceType: ClusterIP
@@ -89,9 +99,9 @@ head:
 
 workers:
 - groupName: small-group
-  replicas: 1
-  minReplicas: 1
-  maxReplicas: 300
+  replicas: 0
+  minReplicas: 0
+  maxReplicas: 10
   labels: {}
   annotations: {}
   rayStartParams:
@@ -118,7 +128,19 @@ workers:
           command: ["/bin/sh","-c","ray stop"]
   nodeSelector: {}
   tolerations: []
+  # - key: "plural.sh/capacityType"
+  #   operator: "Equal"
+  #   value: "SPOT"
+  #   effect: "NoSchedule"
   affinity: {}
+  #   nodeAffinity:
+  #     requiredDuringSchedulingIgnoredDuringExecution:
+  #       nodeSelectorTerms:
+  #       - matchExpressions:
+  #         - key: plural.sh/capacityType
+  #           operator: In
+  #           values:
+  #           - SPOT
   securityContext: {}
   volumes: []
     # - name: log-volume

--- a/ray/helm/ray/values.yaml.tpl
+++ b/ray/helm/ray/values.yaml.tpl
@@ -50,3 +50,16 @@ oauth2-proxy:
 users:
 {{ toYaml .Values.users | nindent 2 }}
 {{ end }}
+
+{{- if .Values.gitSync.enabled }}
+gitSync:
+  enabled: true
+  repo: {{ .Values.gitSync.repo }}
+  {{- if .Values.gitSync.password }}
+  password: {{ .Values.gitSync.password }}
+  username: {{ .Values.gitSync.username }}
+  {{- end }}
+  {{- if .Values.gitSync.branch }}
+  branch: {{ .Values.gitSync.branch }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
## Summary
Allow for easily adding a git-sync sidecar container for the ray head server to sync in python code that should be executed.


## Test Plan
Local linking.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP