### PR TITLE
disable simple loki if distributed loki is deployed

### DIFF
--- a/grafana-tempo/helm/grafana-tempo/Chart.yaml
+++ b/grafana-tempo/helm/grafana-tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: grafana-tempo
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.12
+version: 0.1.13
 appVersion: "1.1.0"
 dependencies:
 - name: tempo-distributed

--- a/grafana-tempo/helm/grafana-tempo/templates/grafana-datasource.yaml
+++ b/grafana-tempo/helm/grafana-tempo/templates/grafana-datasource.yaml
@@ -14,11 +14,15 @@ data:
       access: proxy
       orgId: 1
       uid: tempo
-      url: http://grafana-tempo-tempo-distributed-query-frontend.grafana-tempo:3100
+      url: http://{{ template "tempo.queryFrontendFullname" (index .Subcharts "tempo-distributed") }}.{{ .Release.Namespace }}:3100
       jsonData:
         tracesToLogs:
-            datasourceUid: loki
-            tags:
-              - cluster
-              - namespace
-              - pod
+          {{- if eq .Values.lokiMode "distributed" }}
+          datasourceUid: loki-distributed
+          {{- else }}
+          datasourceUid: loki
+          {{- end }}
+          tags:
+            - cluster
+            - namespace
+            - pod

--- a/grafana-tempo/helm/grafana-tempo/values.yaml
+++ b/grafana-tempo/helm/grafana-tempo/values.yaml
@@ -2,6 +2,9 @@ provider: aws
 tempoStorageIdentityId: 
 tempoStorageIdentityClientId: 
 
+# can be simple or distributed
+lokiMode: simple
+
 tempo-distributed:
   tempo:
     image:

--- a/grafana-tempo/helm/grafana-tempo/values.yaml.tpl
+++ b/grafana-tempo/helm/grafana-tempo/values.yaml.tpl
@@ -11,6 +11,10 @@ tempoStorageIdentityId: {{ importValue "Terraform" "tempo_msi_id" }}
 tempoStorageIdentityClientId: {{ importValue "Terraform" "tempo_msi_client_id" }}
 {{- end }}
 
+{{- if .Configuration.loki }}
+lokiMode: distributed
+{{- end }}
+
 tempo-distributed:
   serviceAccount:
     {{- if eq .Provider "google" }}

--- a/grafana/helm/grafana/Chart.yaml
+++ b/grafana/helm/grafana/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: grafana
 description: A Helm chart for grafana on plural
 type: application
-version: 0.2.13
+version: 0.2.14
 appVersion: "8.3.2"
 dependencies:
 - name: grafana

--- a/grafana/helm/grafana/values.yaml.tpl
+++ b/grafana/helm/grafana/values.yaml.tpl
@@ -36,3 +36,11 @@ grafana:
       role_attribute_path: "null"
       groups_attribute_path: groups
   {{ end }}
+  {{- if .Configuration.loki }}
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      deleteDatasources:
+      - name: Loki
+        orgId: 1
+{{- end }}

--- a/loki/helm/loki/Chart.yaml
+++ b/loki/helm/loki/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: loki
 description: helm chart for loki
 type: application
-version: 0.1.7
+version: 0.1.8
 appVersion: "v2.6.1"
 dependencies:
 - name: loki-distributed

--- a/loki/helm/loki/templates/grafana-datasource.yaml
+++ b/loki/helm/loki/templates/grafana-datasource.yaml
@@ -14,7 +14,7 @@ data:
       access: proxy
       orgId: 1
       uid: loki-distributed
-      url: http://loki-loki-distributed-gateway.loki
+      url: http://{{ template "loki.gatewayFullname" (index .Subcharts "loki-distributed") }}.{{ .Release.Namespace }}
       jsonData:
         manageAlerts: true
         alertmanagerUid: alertmanager

--- a/monitoring/helm/monitoring/Chart.yaml
+++ b/monitoring/helm/monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monitoring
 description: A Helm chart for Kubernetes
 type: application
-version: 0.2.18
+version: 0.2.19
 appVersion: "0.1.0"
 dependencies:
 - name: kube-prometheus-stack

--- a/monitoring/helm/monitoring/Chart.yaml
+++ b/monitoring/helm/monitoring/Chart.yaml
@@ -11,9 +11,11 @@ dependencies:
 - name: loki
   version: 2.9.1
   repository: https://grafana.github.io/helm-charts
+  condition: loki.enabled
 - name: promtail
   version: 3.11.0
   repository: https://grafana.github.io/helm-charts
+  condition: promtail.enabled
 - name: opentelemetry-operator
   version: 0.12.0
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts

--- a/monitoring/helm/monitoring/templates/grafana-datasource.yaml
+++ b/monitoring/helm/monitoring/templates/grafana-datasource.yaml
@@ -14,7 +14,7 @@ data:
       access: proxy
       orgId: 1
       uid: prometheus
-      url: http://monitoring-prometheus.monitoring:9090
+      url: http://{{ template "kube-prometheus-stack.prometheus.crname" (index .Subcharts "kube-prometheus-stack") }}.{{ .Release.Namespace }}:9090
       jsonData:
         manageAlerts: true
         alertmanagerUid: alertmanager
@@ -35,9 +35,10 @@ data:
       access: proxy
       orgId: 1
       uid: alertmanager
-      url: http://monitoring-alertmanager.monitoring:9093
+      url: http://{{ template "kube-prometheus-stack.alertmanager.crname" (index .Subcharts "kube-prometheus-stack") }}.{{ .Release.Namespace }}:9093
       jsonData:
         implementation: prometheus
+{{- if .Values.loki.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -55,7 +56,7 @@ data:
       access: proxy
       orgId: 1
       uid: loki
-      url: http://monitoring-loki.monitoring:3100
+      url: http://{{ template "loki.fullname" .Subcharts.loki }}.{{ .Release.Namespace }}:3100
       jsonData:
         manageAlerts: true
         alertmanagerUid: alertmanager
@@ -65,3 +66,4 @@ data:
             name: TraceID
             url: "$${__value.raw}"
             datasourceUid: tempo
+{{- end }}

--- a/monitoring/helm/monitoring/values.yaml
+++ b/monitoring/helm/monitoring/values.yaml
@@ -3,6 +3,7 @@ global:
     pspEnabled: false
 
 loki:
+  enabled: true
   rbac:
     pspEnabled: false
   image:
@@ -14,6 +15,7 @@ loki:
     prometheus.io/path: /metrics
     prometheus.io/scheme: http
 promtail:
+  enabled: true
   image:
     registry: dkr.plural.sh
     repository: monitoring/grafana/promtail

--- a/monitoring/helm/monitoring/values.yaml.tpl
+++ b/monitoring/helm/monitoring/values.yaml.tpl
@@ -12,6 +12,12 @@ kube-prometheus-stack:
         cluster: {{ .Cluster }}
 
 {{- if .Configuration }}
+{{- if .Configuration.loki }}
+loki:
+  enabled: false
+promtail:
+  enabled: false
+{{- end }}
 {{- if index .Configuration "grafana-tempo" }}
 {{ $tempoNamespace := namespace "grafana-tempo" }}
 opentelemetry-operator:


### PR DESCRIPTION
## Summary
Currently, if people deploy our Loki app the one bundled in monitoring will also still run. This PR disables the simple Loki setup in the monitoring app if the dedicated Loki app is installed.

## Test Plan
Local linking


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP