### PR TITLE
runbooks

### DIFF
--- a/crossplane/helm/crossplane/runbooks/scaling-manual.xml
+++ b/crossplane/helm/crossplane/runbooks/scaling-manual.xml
@@ -1,0 +1,72 @@
+<root gap='medium'>
+    <box pad='small' gap='medium' direction='row' align='center'>
+        <button label='Scale' action='scale' primary='true' headline='true' />
+        <box direction='row' align='center' gap='small'>
+            <box gap='small' align='center'>
+                <timeseries datasource="crossplane-cpu" label="Crossplane CPU Usage" />
+                <text size='small'>You should set a reservation to
+                    roughly correspond to 60% utilization</text>
+            </box>
+            <box gap='small' align='center'>
+                <timeseries datasource="crossplane-memory" label="Crossplane Memory Usage" />
+                <text size='small'>You should set a reservation to
+                    roughly correspond to 80% utilization</text>
+            </box>
+        </box>
+        <box gap='xsmall'>
+            <box gap='xsmall'>
+                <input placeholder="250m" label='Crossplane CPU Request' name='crossplane-cpu'>
+                    <valueFrom
+                            datasource="crossplane"
+                            doc="kubernetes.raw"
+                            path="spec.template.spec.containers[0].resources.requests.cpu" />
+                </input>
+                <input placeholder="1Gi" label='Crossplane Memory Request' name='crossplane-memory'>
+                    <valueFrom
+                            datasource="crossplane"
+                            doc="kubernetes.raw"
+                            path="spec.template.spec.containers[0].resources.requests.memory" />
+                </input>
+            </box>
+        </box>
+    </box>
+    <box pad='small' gap='medium' direction='row' align='center'>
+        <button label='Scale' action='scale' primary='true' headline='true' />
+        <box direction='row' align='center' gap='small'>
+            <box gap='small' align='center'>
+                <timeseries datasource="crossplane-rbac-cpu" label="Crossplane RBAC Manager CPU Usage" />
+                <text size='small'>You should set a reservation to
+                    roughly correspond to 60% utilization</text>
+            </box>
+            <box gap='small' align='center'>
+                <timeseries datasource="crossplane-rbac-memory" label="Crossplane RBAC Manager Memory Usage" />
+                <text size='small'>You should set a reservation to
+                    roughly correspond to 80% utilization</text>
+            </box>
+        </box>
+        <box gap='xsmall'>
+            <box gap='xsmall'>
+                <input placeholder="250m" label='Crossplane RBAC Manager CPU Request' name='crossplane-rbac-cpu'>
+                    <valueFrom
+                            datasource="crossplane-rbac"
+                            doc="kubernetes.raw"
+                            path="spec.template.spec.containers[0].resources.requests.cpu" />
+                </input>
+                <input placeholder="1Gi" label='Crossplane RBAC Manager Memory Request' name='crossplane-rbac-memory'>
+                    <valueFrom
+                            datasource="crossplane-rbac"
+                            doc="kubernetes.raw"
+                            path="spec.template.spec.containers[0].resources.requests.memory" />
+                </input>
+            </box>
+        </box>
+    </box>
+    <box width='100%' gap='small'>
+        <text size='small'>Be sure to scale your crossplane components within your node's capacity, listed here:</text>
+        <table width='100%' datasource='nodes' path='nodes'>
+            <tableColumn path='metadata.name' header='name' width='33%' />
+            <tableColumn path='status.capacity.cpu' header='cpu' width='33%' />
+            <tableColumn path='status.capacity.memory' header='memory' width='33%' />
+        </table>
+    </box>
+</root>

--- a/crossplane/helm/crossplane/templates/runbooks.yaml
+++ b/crossplane/helm/crossplane/templates/runbooks.yaml
@@ -1,0 +1,79 @@
+apiVersion: platform.plural.sh/v1alpha1
+kind: Runbook
+metadata:
+  name: scaling-manual
+  labels:
+    platform.plural.sh/pinned: 'true'
+{{ include "crossplane.labels" . | indent 4 }}
+spec:
+  name: Crossplane Scaling
+  description: overview of how to optimally scale your crossplane cluster
+  display: |-
+{{ .Files.Get "runbooks/scaling-manual.xml" | indent 4 }}
+  datasources:
+  - name: crossplane-cpu
+    type: prometheus
+    prometheus:
+      format: cpu
+      legend: $pod
+      query: sum(rate(container_cpu_usage_seconds_total{namespace="{{ .Release.Namespace }}",pod=~"crossplane.+"}[5m])) by (pod)
+  - name: crossplane-memory
+    type: prometheus
+    prometheus:
+      format: memory
+      legend: $pod
+      query: sum(container_memory_working_set_bytes{namespace="{{ .Release.Namespace }}",pod=~"crossplane.+"}) by (pod)
+  - name: crossplane-rbac-cpu
+    type: prometheus
+    prometheus:
+      format: cpu
+      legend: $pod
+      query: sum(rate(container_cpu_usage_seconds_total{namespace="{{ .Release.Namespace }}",pod=~"crossplane-rbac.+"}[5m])) by (pod)
+  - name: crossplane-rbac-memory
+    type: prometheus
+    prometheus:
+      format: memory
+      legend: $pod
+      query: sum(container_memory_working_set_bytes{namespace="{{ .Release.Namespace }}",pod=~"crossplane-rbac.+"}) by (pod)
+  - name: crossplane
+    type: kubernetes
+    kubernetes:
+      resource: deployment
+      name: crossplane
+  - name: crossplane-rbac
+    type: kubernetes
+    kubernetes:
+      resource: deployment
+      name: crossplane-rbac-manager
+  - name: nodes
+    type: nodes
+  actions:
+  - name: scale
+    action: config
+    redirectTo: '/'
+    configuration:
+      updates:
+        - path:
+            - resourcesCrossplane
+            - resources
+            - requests
+            - cpu
+          valueFrom: crossplane-cpu
+        - path:
+            - resourcesCrossplane
+            - resources
+            - requests
+            - memory
+          valueFrom: crossplane-memory
+        - path:
+            - resourcesRBACManager
+            - resources
+            - requests
+            - cpu
+          valueFrom: crossplane-rbac-cpu
+        - path:
+            - resourcesRBACManager
+            - resources
+            - requests
+            - memory
+          valueFrom: crossplane-rbac-memory

--- a/crossplane/helm/crossplane/values.yaml
+++ b/crossplane/helm/crossplane/values.yaml
@@ -3,3 +3,18 @@ serviceAccount:
     eks.amazonaws.com/role-arn: arn:aws:iam::test:role/test-crossplane
 
 clusterName: ""
+
+resourcesCrossplane:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+
+resourcesRBACManager:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+
+packageCache:
+  medium: ""
+  sizeLimit: 1Mi
+  pvc: ""


### PR DESCRIPTION
Added runbooks and default resources

<!--- Hello Plural contributor! It's great to have you with us! -->

## Summary
Runbooks added for crossplane


## Test Plan
Console UI is displaying correctly the prometheus graphs and scale related fields


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [X]  No images hosted from dockerhub
- [X]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [X]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [X]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [X]  AWS
    - [ ]  GCP