### PR TITLE
add s3 vpc endpoint

### DIFF
--- a/bootstrap/terraform/aws-bootstrap/deps.yaml
+++ b/bootstrap/terraform/aws-bootstrap/deps.yaml
@@ -2,7 +2,7 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: Creates an EKS cluster and prepares it for bootstrapping
-  version: 0.1.42
+  version: 0.1.43
 spec:
   dependencies: []
   providers:

--- a/bootstrap/terraform/aws-bootstrap/s3-vpc-endpoint.tf
+++ b/bootstrap/terraform/aws-bootstrap/s3-vpc-endpoint.tf
@@ -1,0 +1,6 @@
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id       = module.vpc.vpc_id
+  service_name = "com.amazonaws.${var.aws_region}.s3"
+  auto_accept = true
+  route_table_ids = [module.vpc.default_route_table_id]
+}

--- a/bootstrap/terraform/aws-bootstrap/terraform.tfvars
+++ b/bootstrap/terraform/aws-bootstrap/terraform.tfvars
@@ -16,3 +16,5 @@ database_subnets = yamldecode(<<EOT
 EOT
 )
 {{- end }}
+
+aws_region = {{ .Region | quote }}

--- a/bootstrap/terraform/aws-bootstrap/variables.tf
+++ b/bootstrap/terraform/aws-bootstrap/variables.tf
@@ -254,3 +254,9 @@ variable "namespace" {
   type = string
   default = "bootstrap"
 }
+
+variable "aws_region" {
+  type = string
+  default = "us-east-2"
+  description = "The region you wish to deploy to"
+}


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you with us! -->

## Summary

add s3 vpc endpoint to route traffic from within the cluster to S3 without going to the public internet.


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP