### PR TITLE
select subnet route table for s3 vpc endpoint

### DIFF
--- a/bootstrap/terraform/aws-bootstrap/s3-vpc-endpoint.tf
+++ b/bootstrap/terraform/aws-bootstrap/s3-vpc-endpoint.tf
@@ -1,6 +1,10 @@
+data "aws_route_table" "worker_private_subnets_route_table" {
+  subnet_id = module.vpc.worker_private_subnets_ids[0]
+}
+
 resource "aws_vpc_endpoint" "s3" {
   vpc_id       = module.vpc.vpc_id
   service_name = "com.amazonaws.${var.aws_region}.s3"
   auto_accept = true
-  route_table_ids = [module.vpc.default_route_table_id]
+  route_table_ids = [data.aws_route_table.worker_private_subnets_route_table.id]
 }


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you with us! -->

## Summary

earlier today the PR #400 was merged. The purpose was to route traffic from within the cluster to S3 without leaving the aws network. I wanted to make sure the PR really rsolves the issue and looked for a way to validate that the route to S3 does not involve any nodes on the public internet.

I found [this](https://aws.amazon.com/premiumsupport/knowledge-center/vpc-fix-gateway-or-interface-endpoint/?nc1=h_ls) article on how to verify the setup.

Basically, it says that the output of tcptraceroute should not contain any hops. So it should consist only of line with `*` characters like e.g. line 3 in the below screen shot. This screenshot also shows several lines which contain IP addresses. Not sure what those ip addresses belong to, but according to the above article, those lines should not be there.

![image](https://user-images.githubusercontent.com/70146154/197587669-6fac18bf-5be2-49c5-ac5b-01459bef5ac6.png)

In the PR #400 we provided the id of the main route table of the VPC containing our EKS cluster to the terraform configuration of the s3 endpoint.

This new PR uses the id of the route table for the `<cluster_name>-worker-private-<region>` subnets instead. These subnets are also used when creating the `single_az_node_groups` in the `bootstrap` artifact.

After applying the change, I ran tcptraceroute one more time and got the result shown in the screenshot below. This corresponds to the expected result shown in the above article.

![image](https://user-images.githubusercontent.com/70146154/197589352-bb212626-0fa1-460f-b016-d7dd37e45213.png)


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP