### PR TITLE
Update bootstrap for VPN operator

### DIFF
--- a/bootstrap/helm/bootstrap/Chart.yaml
+++ b/bootstrap/helm/bootstrap/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   email: mguarino46@gmail.com
 - name: David van der Spek
   email: david@plural.sh
-version: 0.8.53
+version: 0.8.54
 dependencies:
 - name: external-dns
   version: 4.11.0

--- a/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_configurationoverlays.platform.plural.sh.yaml
+++ b/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_configurationoverlays.platform.plural.sh.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -15,86 +14,86 @@ spec:
     singular: configurationoverlay
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: ConfigurationOverlay is the Schema for the configurationoverlays
-            API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ConfigurationOverlay is the Schema for the configurationoverlays
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ConfigurationOverlaySpec defines the desired state of ConfigurationOverlay
-              properties:
-                documentation:
-                  description: documentation for the specific field
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ConfigurationOverlaySpec defines the desired state of ConfigurationOverlay
+            properties:
+              documentation:
+                description: documentation for the specific field
+                type: string
+              folder:
+                description: Top level folder this overlay should live in, default
+                  is "general"
+                type: string
+              inputType:
+                description: the datatype for the value given to the input field
+                enum:
+                - string
+                - enum
+                - int
+                - list
+                - bool
+                type: string
+              inputValues:
+                description: the values for enum input types
+                items:
                   type: string
-                folder:
-                  description: Top level folder this overlay should live in, default
-                    is "general"
-                  type: string
-                inputType:
-                  description: the datatype for the value given to the input field
-                  enum:
-                    - string
-                    - enum
-                    - int
-                    - list
-                    - bool
-                  type: string
-                inputValues:
-                  description: the values for enum input types
-                  items:
-                    type: string
-                  type: array
-                name:
-                  description: Name of the configuration input field
-                  type: string
-                subfolder:
-                  description: Subfolder this overlay lives in, default is "all"
-                  type: string
-                type:
-                  description: type of configuration value
-                  enum:
-                    - helm
-                    - terraform
-                  type: string
-                updates:
-                  description: configuration path to update against
-                  items:
-                    description: OverlayUpdate defines an update to perform for this
-                      update
-                    properties:
-                      path:
-                        description: the path to update with
-                        items:
-                          type: string
-                        type: array
-                    required:
-                      - path
-                    type: object
-                  type: array
-              required:
-                - documentation
-                - name
-                - updates
-              type: object
-            status:
-              description: ConfigurationOverlayStatus defines the observed state of
-                ConfigurationOverlay
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+              name:
+                description: Name of the configuration input field
+                type: string
+              subfolder:
+                description: Subfolder this overlay lives in, default is "all"
+                type: string
+              type:
+                description: type of configuration value
+                enum:
+                - helm
+                - terraform
+                type: string
+              updates:
+                description: configuration path to update against
+                items:
+                  description: OverlayUpdate defines an update to perform for this
+                    update
+                  properties:
+                    path:
+                      description: the path to update with
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - path
+                  type: object
+                type: array
+            required:
+            - documentation
+            - name
+            - updates
+            type: object
+          status:
+            description: ConfigurationOverlayStatus defines the observed state of
+              ConfigurationOverlay
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_dashboards.platform.plural.sh.yaml
+++ b/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_dashboards.platform.plural.sh.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -15,122 +14,122 @@ spec:
     singular: dashboard
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Dashboard is the Schema for the dashboards API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Dashboard is the Schema for the dashboards API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: DashboardSpec defines the desired state of Dashboard
-              properties:
-                defaultTime:
-                  description: the starting time window for dashboard rendering
-                  type: string
-                description:
-                  description: description for this dashboard
-                  type: string
-                graphs:
-                  description: the graphs to render in the dashboard
-                  items:
-                    description: Specification for a single timeseries graph in a dashboard
-                    properties:
-                      format:
-                        description: specify how y values should be rendered. Can be
-                          any of [bytes, percent, none]
-                        enum:
-                          - bytes
-                          - percent
-                          - none
-                        type: string
-                      name:
-                        description: Name of this graph
-                        type: string
-                      queries:
-                        description: the queries rendered in this graph
-                        items:
-                          description: Specification for a graph query in a dashboard
-                          properties:
-                            legend:
-                              description: The legend name for this query
-                              type: string
-                            legendFormat:
-                              description: The format for the legend
-                              type: string
-                            query:
-                              description: the query to use
-                              type: string
-                          required:
-                            - query
-                          type: object
-                        type: array
-                    required:
-                      - name
-                      - queries
-                    type: object
-                  type: array
-                labels:
-                  description: a list of labels to fetch for filtering dashboard results
-                  items:
-                    description: DashboardLabelSpec is a structure specifying labels
-                      to filter against in a dashboard these can be statically declared
-                      or lazily fetched against the backend metric source
-                    properties:
-                      name:
-                        description: label name
-                        type: string
-                      query:
-                        description: query to fetch the labels from
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DashboardSpec defines the desired state of Dashboard
+            properties:
+              defaultTime:
+                description: the starting time window for dashboard rendering
+                type: string
+              description:
+                description: description for this dashboard
+                type: string
+              graphs:
+                description: the graphs to render in the dashboard
+                items:
+                  description: Specification for a single timeseries graph in a dashboard
+                  properties:
+                    format:
+                      description: specify how y values should be rendered. Can be
+                        any of [bytes, percent, none]
+                      enum:
+                      - bytes
+                      - percent
+                      - none
+                      type: string
+                    name:
+                      description: Name of this graph
+                      type: string
+                    queries:
+                      description: the queries rendered in this graph
+                      items:
+                        description: Specification for a graph query in a dashboard
                         properties:
-                          label:
-                            description: label name
+                          legend:
+                            description: The legend name for this query
+                            type: string
+                          legendFormat:
+                            description: The format for the legend
                             type: string
                           query:
-                            description: the backend query to use
+                            description: the query to use
                             type: string
                         required:
-                          - label
-                          - query
+                        - query
                         type: object
-                      values:
-                        description: statically specified values
-                        items:
+                      type: array
+                  required:
+                  - name
+                  - queries
+                  type: object
+                type: array
+              labels:
+                description: a list of labels to fetch for filtering dashboard results
+                items:
+                  description: DashboardLabelSpec is a structure specifying labels
+                    to filter against in a dashboard these can be statically declared
+                    or lazily fetched against the backend metric source
+                  properties:
+                    name:
+                      description: label name
+                      type: string
+                    query:
+                      description: query to fetch the labels from
+                      properties:
+                        label:
+                          description: label name
                           type: string
-                        type: array
-                    required:
-                      - name
-                    type: object
-                  type: array
-                name:
-                  description: the name for this dashboard
+                        query:
+                          description: the backend query to use
+                          type: string
+                      required:
+                      - label
+                      - query
+                      type: object
+                    values:
+                      description: statically specified values
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - name
+                  type: object
+                type: array
+              name:
+                description: the name for this dashboard
+                type: string
+              timeslices:
+                description: possible time windows for the dashboard to display
+                items:
                   type: string
-                timeslices:
-                  description: possible time windows for the dashboard to display
-                  items:
-                    type: string
-                  type: array
-              required:
-                - defaultTime
-                - graphs
-                - labels
-                - timeslices
-              type: object
-            status:
-              description: DashboardStatus defines the observed state of Dashboard
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+            required:
+            - defaultTime
+            - graphs
+            - labels
+            - timeslices
+            type: object
+          status:
+            description: DashboardStatus defines the observed state of Dashboard
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_defaultstorageclasses.platform.plural.sh.yaml
+++ b/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_defaultstorageclasses.platform.plural.sh.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -15,35 +14,39 @@ spec:
     singular: defaultstorageclass
   scope: Cluster
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: DefaultStorageClass is the Schema for the defaultstorageclasses
-            API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DefaultStorageClass is the Schema for the defaultstorageclasses
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: DefaultStorageClassSpec defines the desired state of DefaultStorageClass
-              properties:
-                name:
-                  type: string
-              type: object
-            status:
-              description: DefaultStorageClassStatus defines the observed state of DefaultStorageClass
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+            type: string
+          metadata:
+            properties:
+              name:
+                pattern: ^default$
+                type: string
+            type: object
+          spec:
+            description: DefaultStorageClassSpec defines the desired state of DefaultStorageClass
+            properties:
+              name:
+                type: string
+            type: object
+          status:
+            description: DefaultStorageClassStatus defines the observed state of DefaultStorageClass
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_licenses.platform.plural.sh.yaml
+++ b/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_licenses.platform.plural.sh.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -15,94 +14,95 @@ spec:
     singular: license
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: License is the Schema for the licenses API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: License is the Schema for the licenses API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: LicenseSpec defines the desired state of License
-              properties:
-                secretRef:
-                  description: the reference to a secret containing your license key
-                  properties:
-                    key:
-                      description: The key of the secret to select from.  Must be a
-                        valid secret key.
-                      type: string
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                    optional:
-                      description: Specify whether the Secret or its key must be defined
-                      type: boolean
-                  required:
-                    - key
-                  type: object
-              required:
-                - secretRef
-              type: object
-            status:
-              description: LicenseStatus defines the observed state of License
-              properties:
-                policy:
-                  description: the policy this license adheres to
-                  properties:
-                    features:
-                      description: the features allowed for this plan
-                      items:
-                        description: LicenseFeature defines a feature allowed by this
-                          license
-                        properties:
-                          description:
-                            description: description of the feature
-                            type: string
-                          name:
-                            description: the name of the feature
-                            type: string
-                        required:
-                          - description
-                          - name
-                        type: object
-                      type: array
-                    free:
-                      description: whether this is on a free plan
-                      type: boolean
-                    limits:
-                      additionalProperties:
-                        format: int64
-                        type: integer
-                      description: limits attached to this plan
-                      type: object
-                    plan:
-                      description: the plan you're on
-                      type: string
-                  required:
-                    - free
-                  type: object
-                secrets:
-                  additionalProperties:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: LicenseSpec defines the desired state of License
+            properties:
+              secretRef:
+                description: the reference to a secret containing your license key
+                properties:
+                  key:
+                    description: The key of the secret to select from.  Must be a
+                      valid secret key.
                     type: string
-                  description: additional secrets attached to this license
-                  type: object
-              required:
-                - policy
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                  optional:
+                    description: Specify whether the Secret or its key must be defined
+                    type: boolean
+                required:
+                - key
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - secretRef
+            type: object
+          status:
+            description: LicenseStatus defines the observed state of License
+            properties:
+              policy:
+                description: the policy this license adheres to
+                properties:
+                  features:
+                    description: the features allowed for this plan
+                    items:
+                      description: LicenseFeature defines a feature allowed by this
+                        license
+                      properties:
+                        description:
+                          description: description of the feature
+                          type: string
+                        name:
+                          description: the name of the feature
+                          type: string
+                      required:
+                      - description
+                      - name
+                      type: object
+                    type: array
+                  free:
+                    description: whether this is on a free plan
+                    type: boolean
+                  limits:
+                    additionalProperties:
+                      format: int64
+                      type: integer
+                    description: limits attached to this plan
+                    type: object
+                  plan:
+                    description: the plan you're on
+                    type: string
+                required:
+                - free
+                type: object
+              secrets:
+                additionalProperties:
+                  type: string
+                description: additional secrets attached to this license
+                type: object
+            required:
+            - policy
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_logfilters.platform.plural.sh.yaml
+++ b/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_logfilters.platform.plural.sh.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -15,60 +14,60 @@ spec:
     singular: logfilter
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: LogFilter is the Schema for the logfilters API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: LogFilter is the Schema for the logfilters API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: LogFilterSpec defines the desired state of LogFilter
-              properties:
-                description:
-                  description: description for this logfilter
-                  type: string
-                labels:
-                  description: labels to query against
-                  items:
-                    description: A label to filter logs against
-                    properties:
-                      name:
-                        description: name of the label
-                        type: string
-                      value:
-                        description: value of the label
-                        type: string
-                    required:
-                      - name
-                      - value
-                    type: object
-                  type: array
-                name:
-                  description: name for this logfilter
-                  type: string
-                query:
-                  description: loki query to use for the filter
-                  type: string
-              required:
-                - description
-                - name
-              type: object
-            status:
-              description: LogFilterStatus defines the observed state of LogFilter
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: LogFilterSpec defines the desired state of LogFilter
+            properties:
+              description:
+                description: description for this logfilter
+                type: string
+              labels:
+                description: labels to query against
+                items:
+                  description: A label to filter logs against
+                  properties:
+                    name:
+                      description: name of the label
+                      type: string
+                    value:
+                      description: value of the label
+                      type: string
+                  required:
+                  - name
+                  - value
+                  type: object
+                type: array
+              name:
+                description: name for this logfilter
+                type: string
+              query:
+                description: loki query to use for the filter
+                type: string
+            required:
+            - description
+            - name
+            type: object
+          status:
+            description: LogFilterStatus defines the observed state of LogFilter
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_logtails.platform.plural.sh.yaml
+++ b/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_logtails.platform.plural.sh.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -15,50 +14,50 @@ spec:
     singular: logtail
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: LogTail is the Schema for the logtails API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: LogTail is the Schema for the logtails API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: LogTailSpec defines the desired state of LogTail
-              properties:
-                container:
-                  description: The specific container to tail
-                  type: string
-                follow:
-                  description: whether to interactively follow the logs
-                  type: boolean
-                limit:
-                  description: number of lines to tail
-                  format: int32
-                  type: integer
-                target:
-                  description: the kubectl-type target to use for this log tail, eg
-                    deployment/name-of-my-deployment
-                  type: string
-              required:
-                - follow
-                - limit
-                - target
-              type: object
-            status:
-              description: LogTailStatus defines the observed state of LogTail
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: LogTailSpec defines the desired state of LogTail
+            properties:
+              container:
+                description: The specific container to tail
+                type: string
+              follow:
+                description: whether to interactively follow the logs
+                type: boolean
+              limit:
+                description: number of lines to tail
+                format: int32
+                type: integer
+              target:
+                description: the kubectl-type target to use for this log tail, eg
+                  deployment/name-of-my-deployment
+                type: string
+            required:
+            - follow
+            - limit
+            - target
+            type: object
+          status:
+            description: LogTailStatus defines the observed state of LogTail
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_proxies.platform.plural.sh.yaml
+++ b/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_proxies.platform.plural.sh.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -15,120 +14,120 @@ spec:
     singular: proxy
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Proxy is the Schema for the proxies API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Proxy is the Schema for the proxies API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ProxySpec defines the desired state of Proxy
-              properties:
-                credentials:
-                  description: credentials to use when authenticating against a proxied
-                    resource
-                  properties:
-                    key:
-                      description: key in the secret to use
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ProxySpec defines the desired state of Proxy
+            properties:
+              credentials:
+                description: credentials to use when authenticating against a proxied
+                  resource
+                properties:
+                  key:
+                    description: key in the secret to use
+                    type: string
+                  secret:
+                    description: secret storing auth info
+                    type: string
+                  user:
+                    description: username to auth with
+                    type: string
+                  userKey:
+                    description: key in the secret that stores the username
+                    type: string
+                required:
+                - key
+                - secret
+                type: object
+              dbConfig:
+                description: db-specific configuration for this proxy
+                properties:
+                  engine:
+                    description: db engine
+                    enum:
+                    - postgres
+                    - mysql
+                    type: string
+                  name:
+                    description: name of the database to connect to
+                    type: string
+                  port:
+                    description: port to use
+                    format: int32
+                    type: integer
+                required:
+                - engine
+                - name
+                - port
+                type: object
+              description:
+                description: Description for this proxy spec
+                type: string
+              shConfig:
+                description: sh-specific configuration for this proxy
+                properties:
+                  args:
+                    description: arguments to pass to the command
+                    items:
                       type: string
-                    secret:
-                      description: secret storing auth info
-                      type: string
-                    user:
-                      description: username to auth with
-                      type: string
-                    userKey:
-                      description: key in the secret that stores the username
-                      type: string
-                  required:
-                    - key
-                    - secret
-                  type: object
-                dbConfig:
-                  description: db-specific configuration for this proxy
-                  properties:
-                    engine:
-                      description: db engine
-                      enum:
-                        - postgres
-                        - mysql
-                      type: string
-                    name:
-                      description: name of the database to connect to
-                      type: string
-                    port:
-                      description: port to use
-                      format: int32
-                      type: integer
-                  required:
-                    - engine
-                    - name
-                    - port
-                  type: object
-                description:
-                  description: Description for this proxy spec
-                  type: string
-                shConfig:
-                  description: sh-specific configuration for this proxy
-                  properties:
-                    args:
-                      description: arguments to pass to the command
-                      items:
-                        type: string
-                      type: array
-                    command:
-                      description: command to execute in the proxied pod
-                      type: string
-                    container:
-                      description: The container name to shell into (if the pod has
-                        multiple containers configured)
-                      type: string
-                  required:
-                    - command
-                  type: object
-                target:
-                  description: selector to set up the proxy against
-                  type: string
-                type:
-                  description: the type of proxy to use, can be a db, shell or web proxy
-                  enum:
-                    - db
-                    - sh
-                    - web
-                  type: string
-                webConfig:
-                  description: web-specific configuration for this proxy
-                  properties:
-                    path:
-                      description: path to direct users to on sign-in
-                      type: string
-                    port:
-                      description: port of the service to forward
-                      format: int32
-                      type: integer
-                  required:
-                    - port
-                  type: object
-              required:
-                - target
-                - type
-              type: object
-            status:
-              description: ProxyStatus defines the observed state of Proxy
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                    type: array
+                  command:
+                    description: command to execute in the proxied pod
+                    type: string
+                  container:
+                    description: The container name to shell into (if the pod has
+                      multiple containers configured)
+                    type: string
+                required:
+                - command
+                type: object
+              target:
+                description: selector to set up the proxy against
+                type: string
+              type:
+                description: the type of proxy to use, can be a db, shell or web proxy
+                enum:
+                - db
+                - sh
+                - web
+                type: string
+              webConfig:
+                description: web-specific configuration for this proxy
+                properties:
+                  path:
+                    description: path to direct users to on sign-in
+                    type: string
+                  port:
+                    description: port of the service to forward
+                    format: int32
+                    type: integer
+                required:
+                - port
+                type: object
+            required:
+            - target
+            - type
+            type: object
+          status:
+            description: ProxyStatus defines the observed state of Proxy
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_registrycredentials.platform.plural.sh.yaml
+++ b/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_registrycredentials.platform.plural.sh.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -15,60 +14,61 @@ spec:
     singular: registrycredential
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: RegistryCredentialSpec is a specification of registry credentials
-              properties:
-                email:
-                  description: Registry user email address
-                  type: string
-                password:
-                  description: The password Secret to select from
-                  properties:
-                    key:
-                      description: Key for Secret data
-                      type: string
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RegistryCredentialSpec is a specification of registry credentials
+            properties:
+              email:
+                description: Registry user email address
+                type: string
+              password:
+                description: The password Secret to select from
+                properties:
+                  key:
+                    description: Key for Secret data
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                  required:
-                    - key
-                  type: object
-                server:
-                  description: Registry FQDN
-                  type: string
-                username:
-                  description: Registry username
-                  type: string
-              required:
-                - email
-                - password
-                - server
-                - username
-              type: object
-            status:
-              description: RegistryCredentialStatus defines the observed state of RegistryCredential
-              type: object
-          required:
-            - spec
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                    type: string
+                required:
+                - key
+                type: object
+                x-kubernetes-map-type: atomic
+              server:
+                description: Registry FQDN
+                type: string
+              username:
+                description: Registry username
+                type: string
+            required:
+            - email
+            - password
+            - server
+            - username
+            type: object
+          status:
+            description: RegistryCredentialStatus defines the observed state of RegistryCredential
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_resourcegroups.platform.plural.sh.yaml
+++ b/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_resourcegroups.platform.plural.sh.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -15,100 +14,101 @@ spec:
     singular: resourcegroup
   scope: Cluster
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: ResourceGroup is the Schema for the resourcegroups API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ResourceGroup is the Schema for the resourcegroups API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ResourceGroupSpec defines the desired state of ResourceGroup
-              properties:
-                selector:
-                  description: the node selector to use for this group
-                  properties:
-                    matchExpressions:
-                      description: A list of node selector requirements by node's labels.
-                      items:
-                        description: A node selector requirement is a selector that
-                          contains values, a key, and an operator that relates the key
-                          and values.
-                        properties:
-                          key:
-                            description: The label key that the selector applies to.
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ResourceGroupSpec defines the desired state of ResourceGroup
+            properties:
+              selector:
+                description: the node selector to use for this group
+                properties:
+                  matchExpressions:
+                    description: A list of node selector requirements by node's labels.
+                    items:
+                      description: A node selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: The label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: Represents a key's relationship to a set of
+                            values. Valid operators are In, NotIn, Exists, DoesNotExist.
+                            Gt, and Lt.
+                          type: string
+                        values:
+                          description: An array of string values. If the operator
+                            is In or NotIn, the values array must be non-empty. If
+                            the operator is Exists or DoesNotExist, the values array
+                            must be empty. If the operator is Gt or Lt, the values
+                            array must have a single element, which will be interpreted
+                            as an integer. This array is replaced during a strategic
+                            merge patch.
+                          items:
                             type: string
-                          operator:
-                            description: Represents a key's relationship to a set of
-                              values. Valid operators are In, NotIn, Exists, DoesNotExist.
-                              Gt, and Lt.
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchFields:
+                    description: A list of node selector requirements by node's fields.
+                    items:
+                      description: A node selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: The label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: Represents a key's relationship to a set of
+                            values. Valid operators are In, NotIn, Exists, DoesNotExist.
+                            Gt, and Lt.
+                          type: string
+                        values:
+                          description: An array of string values. If the operator
+                            is In or NotIn, the values array must be non-empty. If
+                            the operator is Exists or DoesNotExist, the values array
+                            must be empty. If the operator is Gt or Lt, the values
+                            array must have a single element, which will be interpreted
+                            as an integer. This array is replaced during a strategic
+                            merge patch.
+                          items:
                             type: string
-                          values:
-                            description: An array of string values. If the operator
-                              is In or NotIn, the values array must be non-empty. If
-                              the operator is Exists or DoesNotExist, the values array
-                              must be empty. If the operator is Gt or Lt, the values
-                              array must have a single element, which will be interpreted
-                              as an integer. This array is replaced during a strategic
-                              merge patch.
-                            items:
-                              type: string
-                            type: array
-                        required:
-                          - key
-                          - operator
-                        type: object
-                      type: array
-                    matchFields:
-                      description: A list of node selector requirements by node's fields.
-                      items:
-                        description: A node selector requirement is a selector that
-                          contains values, a key, and an operator that relates the key
-                          and values.
-                        properties:
-                          key:
-                            description: The label key that the selector applies to.
-                            type: string
-                          operator:
-                            description: Represents a key's relationship to a set of
-                              values. Valid operators are In, NotIn, Exists, DoesNotExist.
-                              Gt, and Lt.
-                            type: string
-                          values:
-                            description: An array of string values. If the operator
-                              is In or NotIn, the values array must be non-empty. If
-                              the operator is Exists or DoesNotExist, the values array
-                              must be empty. If the operator is Gt or Lt, the values
-                              array must have a single element, which will be interpreted
-                              as an integer. This array is replaced during a strategic
-                              merge patch.
-                            items:
-                              type: string
-                            type: array
-                        required:
-                          - key
-                          - operator
-                        type: object
-                      type: array
-                  type: object
-              required:
-                - selector
-              type: object
-            status:
-              description: ResourceGroupStatus defines the observed state of ResourceGroup
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - selector
+            type: object
+          status:
+            description: ResourceGroupStatus defines the observed state of ResourceGroup
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_runbooks.platform.plural.sh.yaml
+++ b/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_runbooks.platform.plural.sh.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -15,231 +14,231 @@ spec:
     singular: runbook
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Runbook is the Schema for the runbooks API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Runbook is the Schema for the runbooks API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: RunbookSpec defines the desired state of Runbook
-              properties:
-                actions:
-                  description: actions that can be performed in a runbook. These will
-                    be references in input forms
-                  items:
-                    description: RunbookAction represents an action to be performed
-                      in a runbook
-                    properties:
-                      action:
-                        description: The type of this action, eg config or kubernetes
-                        enum:
-                          - config
-                        type: string
-                      configuration:
-                        description: The details of a configuration action
-                        properties:
-                          statefulSets:
-                            description: stateful sets to clean before rebuilding (for
-                              pvc resizes)
-                            items:
-                              description: details for any statefulset resizes to apply
-                              properties:
-                                force:
-                                  description: force completion even if a recreation
-                                    of the statefulset fails (useful for some operator
-                                    interactions)
-                                  type: boolean
-                                name:
-                                  description: name of statefulset
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RunbookSpec defines the desired state of Runbook
+            properties:
+              actions:
+                description: actions that can be performed in a runbook. These will
+                  be references in input forms
+                items:
+                  description: RunbookAction represents an action to be performed
+                    in a runbook
+                  properties:
+                    action:
+                      description: The type of this action, eg config or kubernetes
+                      enum:
+                      - config
+                      type: string
+                    configuration:
+                      description: The details of a configuration action
+                      properties:
+                        statefulSets:
+                          description: stateful sets to clean before rebuilding (for
+                            pvc resizes)
+                          items:
+                            description: details for any statefulset resizes to apply
+                            properties:
+                              force:
+                                description: force completion even if a recreation
+                                  of the statefulset fails (useful for some operator
+                                  interactions)
+                                type: boolean
+                              name:
+                                description: name of statefulset
+                                type: string
+                              persistentVolume:
+                                description: persistent volume to resize
+                                type: string
+                              valueFrom:
+                                description: the value to use from the args for the
+                                  execution
+                                type: string
+                            required:
+                            - name
+                            - persistentVolume
+                            - valueFrom
+                            type: object
+                          type: array
+                        updates:
+                          description: The updates you want to perform
+                          items:
+                            description: An update to a configuration path
+                            properties:
+                              path:
+                                description: path in the configuration to update
+                                items:
                                   type: string
-                                persistentVolume:
-                                  description: persistent volume to resize
-                                  type: string
-                                valueFrom:
-                                  description: the value to use from the args for the
-                                    execution
-                                  type: string
-                              required:
-                                - name
-                                - persistentVolume
-                                - valueFrom
-                              type: object
-                            type: array
-                          updates:
-                            description: The updates you want to perform
-                            items:
-                              description: An update to a configuration path
-                              properties:
-                                path:
-                                  description: path in the configuration to update
-                                  items:
-                                    type: string
-                                  type: array
-                                valueFrom:
-                                  description: the value to use from the args for this
-                                    execution
-                                  type: string
-                              required:
-                                - path
-                                - valueFrom
-                              type: object
-                            type: array
-                        required:
-                          - updates
-                        type: object
-                      name:
-                        description: The name to reference this action
-                        type: string
-                      redirectTo:
-                        description: The url to redirect to after executing this action
-                        type: string
-                    required:
-                      - action
+                                type: array
+                              valueFrom:
+                                description: the value to use from the args for this
+                                  execution
+                                type: string
+                            required:
+                            - path
+                            - valueFrom
+                            type: object
+                          type: array
+                      required:
+                      - updates
+                      type: object
+                    name:
+                      description: The name to reference this action
+                      type: string
+                    redirectTo:
+                      description: The url to redirect to after executing this action
+                      type: string
+                  required:
+                  - action
+                  - name
+                  type: object
+                type: array
+              alerts:
+                description: alerts to tie to this runbook
+                items:
+                  description: RunbookAlert represents an alert to join to this runbook
+                  properties:
+                    name:
+                      description: the name of the alert
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              datasources:
+                description: datasources to hydrate graphs and tables in the runbooks
+                  display
+                items:
+                  description: RunbookDatasource defines the query to extract data
+                    for a runbook
+                  properties:
+                    kubernetes:
+                      description: a kubernetes datasource spec
+                      properties:
+                        name:
+                          description: the name of this resource
+                          type: string
+                        resource:
+                          description: the kubernetes resource kind, eg deployment
+                          enum:
+                          - deployment
+                          - statefulset
+                          type: string
+                      required:
                       - name
-                    type: object
-                  type: array
-                alerts:
-                  description: alerts to tie to this runbook
-                  items:
-                    description: RunbookAlert represents an alert to join to this runbook
-                    properties:
-                      name:
-                        description: the name of the alert
-                        type: string
-                    required:
-                      - name
-                    type: object
-                  type: array
-                datasources:
-                  description: datasources to hydrate graphs and tables in the runbooks
-                    display
-                  items:
-                    description: RunbookDatasource defines the query to extract data
-                      for a runbook
-                    properties:
-                      kubernetes:
-                        description: a kubernetes datasource spec
-                        properties:
-                          name:
-                            description: the name of this resource
-                            type: string
-                          resource:
-                            description: the kubernetes resource kind, eg deployment
-                            enum:
-                              - deployment
-                              - statefulset
-                            type: string
-                        required:
-                          - name
-                          - resource
-                        type: object
-                      name:
-                        description: The name to reference this datasource
-                        type: string
-                      prometheus:
-                        description: a prometheus query spec
-                        properties:
-                          format:
-                            description: the format for the value returned
-                            enum:
-                              - cpu
-                              - memory
-                              - none
-                            type: string
-                          legend:
-                            description: the legend to use in the graph of this metric
-                            type: string
-                          query:
-                            description: the prometheus query
-                            type: string
-                        required:
-                          - format
-                          - legend
-                          - query
-                        type: object
-                      type:
-                        description: The type of this datasource
-                        enum:
-                          - prometheus
-                          - kubernetes
-                          - nodes
-                        type: string
-                    required:
-                      - name
-                      - type
-                    type: object
-                  type: array
-                description:
-                  description: Short description of what this runbook does
-                  type: string
-                display:
-                  description: the display in supported xml for the runbook in the console
-                    UI
-                  type: string
-                name:
-                  description: The name for the runbook displayed in the plural console
-                  type: string
-              required:
-                - actions
-                - description
-                - display
-                - name
-              type: object
-            status:
-              description: RunbookStatus defines the observed state of Runbook
-              properties:
-                alerts:
-                  description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                      - resource
+                      type: object
+                    name:
+                      description: The name to reference this datasource
+                      type: string
+                    prometheus:
+                      description: a prometheus query spec
+                      properties:
+                        format:
+                          description: the format for the value returned
+                          enum:
+                          - cpu
+                          - memory
+                          - none
+                          type: string
+                        legend:
+                          description: the legend to use in the graph of this metric
+                          type: string
+                        query:
+                          description: the prometheus query
+                          type: string
+                      required:
+                      - format
+                      - legend
+                      - query
+                      type: object
+                    type:
+                      description: The type of this datasource
+                      enum:
+                      - prometheus
+                      - kubernetes
+                      - nodes
+                      type: string
+                  required:
+                  - name
+                  - type
+                  type: object
+                type: array
+              description:
+                description: Short description of what this runbook does
+                type: string
+              display:
+                description: the display in supported xml for the runbook in the console
+                  UI
+                type: string
+              name:
+                description: The name for the runbook displayed in the plural console
+                type: string
+            required:
+            - actions
+            - description
+            - display
+            - name
+            type: object
+          status:
+            description: RunbookStatus defines the observed state of Runbook
+            properties:
+              alerts:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
                   of cluster Important: Run "make" to regenerate code after modifying
                   this file'
-                  items:
-                    description: RunbookAlertStatus represents the status of an alert
-                      joined to a runbook
-                    properties:
-                      annotations:
-                        additionalProperties:
-                          type: string
-                        description: the alert annotations
-                        type: object
-                      fingerprint:
-                        description: the fingerprint of this alert
+                items:
+                  description: RunbookAlertStatus represents the status of an alert
+                    joined to a runbook
+                  properties:
+                    annotations:
+                      additionalProperties:
                         type: string
-                      labels:
-                        additionalProperties:
-                          type: string
-                        description: the alert labels
-                        type: object
-                      name:
-                        description: the name of the alert
+                      description: the alert annotations
+                      type: object
+                    fingerprint:
+                      description: the fingerprint of this alert
+                      type: string
+                    labels:
+                      additionalProperties:
                         type: string
-                      startsAt:
-                        description: the time it fired
-                        type: string
-                    required:
-                      - annotations
-                      - fingerprint
-                      - labels
-                      - name
-                      - startsAt
-                    type: object
-                  type: array
-              required:
-                - alerts
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                      description: the alert labels
+                      type: object
+                    name:
+                      description: the name of the alert
+                      type: string
+                    startsAt:
+                      description: the time it fired
+                      type: string
+                  required:
+                  - annotations
+                  - fingerprint
+                  - labels
+                  - name
+                  - startsAt
+                  type: object
+                type: array
+            required:
+            - alerts
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_secretsyncs.platform.plural.sh.yaml
+++ b/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_secretsyncs.platform.plural.sh.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -15,39 +14,39 @@ spec:
     singular: secretsync
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: SecretSync is the Schema for the secretsyncs API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SecretSync is the Schema for the secretsyncs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: SecretSyncSpec defines the desired state of SecretSync
-              properties:
-                name:
-                  description: The secrets name that you intend to sync into the current
-                    namespace
-                  type: string
-                namespace:
-                  description: the namespace for the synced secrets
-                  type: string
-              type: object
-            status:
-              description: SecretSyncStatus defines the observed state of SecretSync
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SecretSyncSpec defines the desired state of SecretSync
+            properties:
+              name:
+                description: The secrets name that you intend to sync into the current
+                  namespace
+                type: string
+              namespace:
+                description: the namespace for the synced secrets
+                type: string
+            type: object
+          status:
+            description: SecretSyncStatus defines the observed state of SecretSync
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_slashcommands.platform.plural.sh.yaml
+++ b/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_slashcommands.platform.plural.sh.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -15,43 +14,43 @@ spec:
     singular: slashcommand
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: SlashCommand is the Schema for the slashcommands API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SlashCommand is the Schema for the slashcommands API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: SlashCommandSpec a slack-type slash command for use in incident
-                chats
-              properties:
-                help:
-                  description: a markdown help doc for this command
-                  type: string
-                type:
-                  description: the slash command to type
-                  enum:
-                    - deploy
-                  type: string
-              required:
-                - help
-              type: object
-            status:
-              description: SlashCommandStatus defines the observed state of SlashCommand
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SlashCommandSpec a slack-type slash command for use in incident
+              chats
+            properties:
+              help:
+                description: a markdown help doc for this command
+                type: string
+              type:
+                description: the slash command to type
+                enum:
+                - deploy
+                type: string
+            required:
+            - help
+            type: object
+          status:
+            description: SlashCommandStatus defines the observed state of SlashCommand
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_statefulsetresizes.platform.plural.sh.yaml
+++ b/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_statefulsetresizes.platform.plural.sh.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -15,45 +14,45 @@ spec:
     singular: statefulsetresize
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: StatefulSetResize is the Schema for the statefulsetresizes API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: StatefulSetResize is the Schema for the statefulsetresizes API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: StatefulSetResizeSpec defines the desired state of StatefulSetResize
-              properties:
-                force:
-                  description: force completion even if a recreation of the statefulset
-                    fails (useful for some operator interactions)
-                  type: boolean
-                name:
-                  description: Name of the stateful set
-                  type: string
-                persistentVolume:
-                  description: Name of the persistent volume you wish to resize
-                  type: string
-                size:
-                  description: Size you want to set it to
-                  type: string
-              type: object
-            status:
-              description: StatefulSetResizeStatus defines the observed state of StatefulSetResize
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: StatefulSetResizeSpec defines the desired state of StatefulSetResize
+            properties:
+              force:
+                description: force completion even if a recreation of the statefulset
+                  fails (useful for some operator interactions)
+                type: boolean
+              name:
+                description: Name of the stateful set
+                type: string
+              persistentVolume:
+                description: Name of the persistent volume you wish to resize
+                type: string
+              size:
+                description: Size you want to set it to
+                type: string
+            type: object
+          status:
+            description: StatefulSetResizeStatus defines the observed state of StatefulSetResize
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_wireguardpeers.vpn.plural.sh.yaml
+++ b/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_wireguardpeers.vpn.plural.sh.yaml
@@ -1,0 +1,164 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: wireguardpeers.vpn.plural.sh
+spec:
+  group: vpn.plural.sh
+  names:
+    kind: WireguardPeer
+    listKind: WireguardPeerList
+    plural: wireguardpeers
+    singular: wireguardpeer
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The Wireguard Server this peer belongs to
+      jsonPath: .spec.wireguardRef
+      name: Wireguard Server
+      type: string
+    - description: The IP address of this wireguard peer
+      jsonPath: .spec.address
+      name: Address
+      type: string
+    - description: The name of the secret containing the configuration of the wireguard
+        peer
+      jsonPath: .status.configRef.name
+      name: Config Secret
+      type: string
+    - description: WireguardPeer ready status
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: WireguardPeer is the Schema for the wireguardpeers API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: WireguardPeerSpec defines the desired state of WireguardPeer
+            properties:
+              PrivateKeyRef:
+                description: reference to the secret and key containing the private
+                  key of the wireguard peer
+                properties:
+                  key:
+                    description: The key of the secret to select from.  Must be a
+                      valid secret key.
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                  optional:
+                    description: Specify whether the Secret or its key must be defined
+                    type: boolean
+                required:
+                - key
+                type: object
+                x-kubernetes-map-type: atomic
+              address:
+                description: the IP address of the wireguard peer
+                type: string
+              publicKey:
+                description: the public key of the wireguard peer
+                type: string
+              wireguardRef:
+                description: the name of the active wireguard instance
+                minLength: 1
+                type: string
+            required:
+            - wireguardRef
+            type: object
+          status:
+            description: WireguardPeerStatus defines the observed state of WireguardPeer
+            properties:
+              conditions:
+                description: Conditions defines current service state of the PacketMachine.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              config:
+                description: The configuration of the wireguard peer without the private
+                  key
+                type: string
+              configRef:
+                description: Reference to the secret containing the configuration
+                  of the wireguard peer
+                properties:
+                  key:
+                    description: The key of the secret to select from.  Must be a
+                      valid secret key.
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                  optional:
+                    description: Specify whether the Secret or its key must be defined
+                    type: boolean
+                required:
+                - key
+                type: object
+                x-kubernetes-map-type: atomic
+              ready:
+                description: Ready is true when the provider resource is ready.
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_wireguardservers.vpn.plural.sh.yaml
+++ b/bootstrap/helm/bootstrap/crds/apiextensions.k8s.io_v1_customresourcedefinition_wireguardservers.vpn.plural.sh.yaml
@@ -1,0 +1,1398 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: wireguardservers.vpn.plural.sh
+spec:
+  group: vpn.plural.sh
+  names:
+    kind: WireguardServer
+    listKind: WireguardServerList
+    plural: wireguardservers
+    singular: wireguardserver
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: WireguardServer hostname
+      jsonPath: .status.hostname
+      name: Hostname
+      type: string
+    - description: WireguardServer port
+      jsonPath: .status.port
+      name: Port
+      type: string
+    - description: WireguardServer ready status
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: WireguardServer is the Schema for the wireguardservers API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: WireguardServerSpec defines the desired state of WireguardServer
+            properties:
+              allowedIPs:
+                description: The CIDRs that peers can connect to through the wireguard
+                  server. Use 0.0.0.0/0 to allow all.
+                items:
+                  type: string
+                type: array
+              dns:
+                description: The DNS servers to use for the wireguard server
+                items:
+                  type: string
+                type: array
+              enableHA:
+                default: false
+                description: Deploy 3 wireguard servers so that the VPN can be highly
+                  available and spread over 3 availability zones
+                type: boolean
+              mtu:
+                description: Network MTU to use for the VPN
+                type: string
+              networkCIDR:
+                default: 10.8.0.1/24
+                description: The CIDR to use for the wireguard server and network
+                type: string
+              port:
+                description: Port for the wireguard server
+                format: int32
+                type: integer
+              resources:
+                description: The resources to set for the wireguard server
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              serviceAnnotations:
+                additionalProperties:
+                  type: string
+                description: ServiceAnnotations for wireguard k8s service
+                type: object
+              serviceType:
+                description: Service type to use for the VPN
+                type: string
+              sidecars:
+                description: Sidecars for wireguard k8s deployment
+                items:
+                  description: A single application container that you want to run
+                    within a pod.
+                  properties:
+                    args:
+                      description: 'Arguments to the entrypoint. The container image''s
+                        CMD is used if this is not provided. Variable references $(VAR_NAME)
+                        are expanded using the container''s environment. If a variable
+                        cannot be resolved, the reference in the input string will
+                        be unchanged. Double $$ are reduced to a single $, which allows
+                        for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                        produce the string literal "$(VAR_NAME)". Escaped references
+                        will never be expanded, regardless of whether the variable
+                        exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                      items:
+                        type: string
+                      type: array
+                    command:
+                      description: 'Entrypoint array. Not executed within a shell.
+                        The container image''s ENTRYPOINT is used if this is not provided.
+                        Variable references $(VAR_NAME) are expanded using the container''s
+                        environment. If a variable cannot be resolved, the reference
+                        in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax:
+                        i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether
+                        the variable exists or not. Cannot be updated. More info:
+                        https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                      items:
+                        type: string
+                      type: array
+                    env:
+                      description: List of environment variables to set in the container.
+                        Cannot be updated.
+                      items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
+                        properties:
+                          name:
+                            description: Name of the environment variable. Must be
+                              a C_IDENTIFIER.
+                            type: string
+                          value:
+                            description: 'Variable references $(VAR_NAME) are expanded
+                              using the previously defined environment variables in
+                              the container and any service environment variables.
+                              If a variable cannot be resolved, the reference in the
+                              input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME)
+                              syntax: i.e. "$$(VAR_NAME)" will produce the string
+                              literal "$(VAR_NAME)". Escaped references will never
+                              be expanded, regardless of whether the variable exists
+                              or not. Defaults to "".'
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                description: 'Selects a field of the pod: supports
+                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                  `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                  spec.serviceAccountName, status.hostIP, status.podIP,
+                                  status.podIPs.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, limits.ephemeral-storage, requests.cpu,
+                                  requests.memory and requests.ephemeral-storage)
+                                  are currently supported.'
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    envFrom:
+                      description: List of sources to populate environment variables
+                        in the container. The keys defined within a source must be
+                        a C_IDENTIFIER. All invalid keys will be reported as an event
+                        when the container is starting. When a key exists in multiple
+                        sources, the value associated with the last source will take
+                        precedence. Values defined by an Env with a duplicate key
+                        will take precedence. Cannot be updated.
+                      items:
+                        description: EnvFromSource represents the source of a set
+                          of ConfigMaps
+                        properties:
+                          configMapRef:
+                            description: The ConfigMap to select from
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap must be
+                                  defined
+                                type: boolean
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          prefix:
+                            description: An optional identifier to prepend to each
+                              key in the ConfigMap. Must be a C_IDENTIFIER.
+                            type: string
+                          secretRef:
+                            description: The Secret to select from
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret must be defined
+                                type: boolean
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      type: array
+                    image:
+                      description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                        This field is optional to allow higher level config management
+                        to default or override container images in workload controllers
+                        like Deployments and StatefulSets.'
+                      type: string
+                    imagePullPolicy:
+                      description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                        Defaults to Always if :latest tag is specified, or IfNotPresent
+                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                      type: string
+                    lifecycle:
+                      description: Actions that the management system should take
+                        in response to container lifecycle events. Cannot be updated.
+                      properties:
+                        postStart:
+                          description: 'PostStart is called immediately after a container
+                            is created. If the handler fails, the container is terminated
+                            and restarted according to its restart policy. Other management
+                            of the container blocks until the hook completes. More
+                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            tcpSocket:
+                              description: Deprecated. TCPSocket is NOT supported
+                                as a LifecycleHandler and kept for the backward compatibility.
+                                There are no validation of this field and lifecycle
+                                hooks will fail in runtime when tcp handler is specified.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                          type: object
+                        preStop:
+                          description: 'PreStop is called immediately before a container
+                            is terminated due to an API request or management event
+                            such as liveness/startup probe failure, preemption, resource
+                            contention, etc. The handler is not called if the container
+                            crashes or exits. The Pod''s termination grace period
+                            countdown begins before the PreStop hook is executed.
+                            Regardless of the outcome of the handler, the container
+                            will eventually terminate within the Pod''s termination
+                            grace period (unless delayed by finalizers). Other management
+                            of the container blocks until the hook completes or until
+                            the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            tcpSocket:
+                              description: Deprecated. TCPSocket is NOT supported
+                                as a LifecycleHandler and kept for the backward compatibility.
+                                There are no validation of this field and lifecycle
+                                hooks will fail in runtime when tcp handler is specified.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                          type: object
+                      type: object
+                    livenessProbe:
+                      description: 'Periodic probe of container liveness. Container
+                        will be restarted if the probe fails. Cannot be updated. More
+                        info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        failureThreshold:
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        grpc:
+                          description: GRPC specifies an action involving a GRPC port.
+                            This is a beta field and requires enabling GRPCContainerProbe
+                            feature gate.
+                          properties:
+                            port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
+                              format: int32
+                              type: integer
+                            service:
+                              description: "Service is the name of the service to
+                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                \n If this is not specified, the default behavior
+                                is defined by gRPC."
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        initialDelaySeconds:
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                        periodSeconds:
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness and startup. Minimum value
+                            is 1.
+                          format: int32
+                          type: integer
+                        tcpSocket:
+                          description: TCPSocket specifies an action involving a TCP
+                            port.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs
+                            to terminate gracefully upon probe failure. The grace
+                            period is the duration in seconds after the processes
+                            running in the pod are sent a termination signal and the
+                            time when the processes are forcibly halted with a kill
+                            signal. Set this value longer than the expected cleanup
+                            time for your process. If this value is nil, the pod's
+                            terminationGracePeriodSeconds will be used. Otherwise,
+                            this value overrides the value provided by the pod spec.
+                            Value must be non-negative integer. The value zero indicates
+                            stop immediately via the kill signal (no opportunity to
+                            shut down). This is a beta field and requires enabling
+                            ProbeTerminationGracePeriod feature gate. Minimum value
+                            is 1. spec.terminationGracePeriodSeconds is used if unset.
+                          format: int64
+                          type: integer
+                        timeoutSeconds:
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                      type: object
+                    name:
+                      description: Name of the container specified as a DNS_LABEL.
+                        Each container in a pod must have a unique name (DNS_LABEL).
+                        Cannot be updated.
+                      type: string
+                    ports:
+                      description: List of ports to expose from the container. Exposing
+                        a port here gives the system additional information about
+                        the network connections a container uses, but is primarily
+                        informational. Not specifying a port here DOES NOT prevent
+                        that port from being exposed. Any port which is listening
+                        on the default "0.0.0.0" address inside a container will be
+                        accessible from the network. Cannot be updated.
+                      items:
+                        description: ContainerPort represents a network port in a
+                          single container.
+                        properties:
+                          containerPort:
+                            description: Number of port to expose on the pod's IP
+                              address. This must be a valid port number, 0 < x < 65536.
+                            format: int32
+                            type: integer
+                          hostIP:
+                            description: What host IP to bind the external port to.
+                            type: string
+                          hostPort:
+                            description: Number of port to expose on the host. If
+                              specified, this must be a valid port number, 0 < x <
+                              65536. If HostNetwork is specified, this must match
+                              ContainerPort. Most containers do not need this.
+                            format: int32
+                            type: integer
+                          name:
+                            description: If specified, this must be an IANA_SVC_NAME
+                              and unique within the pod. Each named port in a pod
+                              must have a unique name. Name for the port that can
+                              be referred to by services.
+                            type: string
+                          protocol:
+                            default: TCP
+                            description: Protocol for port. Must be UDP, TCP, or SCTP.
+                              Defaults to "TCP".
+                            type: string
+                        required:
+                        - containerPort
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - containerPort
+                      - protocol
+                      x-kubernetes-list-type: map
+                    readinessProbe:
+                      description: 'Periodic probe of container service readiness.
+                        Container will be removed from service endpoints if the probe
+                        fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        failureThreshold:
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        grpc:
+                          description: GRPC specifies an action involving a GRPC port.
+                            This is a beta field and requires enabling GRPCContainerProbe
+                            feature gate.
+                          properties:
+                            port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
+                              format: int32
+                              type: integer
+                            service:
+                              description: "Service is the name of the service to
+                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                \n If this is not specified, the default behavior
+                                is defined by gRPC."
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        initialDelaySeconds:
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                        periodSeconds:
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness and startup. Minimum value
+                            is 1.
+                          format: int32
+                          type: integer
+                        tcpSocket:
+                          description: TCPSocket specifies an action involving a TCP
+                            port.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs
+                            to terminate gracefully upon probe failure. The grace
+                            period is the duration in seconds after the processes
+                            running in the pod are sent a termination signal and the
+                            time when the processes are forcibly halted with a kill
+                            signal. Set this value longer than the expected cleanup
+                            time for your process. If this value is nil, the pod's
+                            terminationGracePeriodSeconds will be used. Otherwise,
+                            this value overrides the value provided by the pod spec.
+                            Value must be non-negative integer. The value zero indicates
+                            stop immediately via the kill signal (no opportunity to
+                            shut down). This is a beta field and requires enabling
+                            ProbeTerminationGracePeriod feature gate. Minimum value
+                            is 1. spec.terminationGracePeriodSeconds is used if unset.
+                          format: int64
+                          type: integer
+                        timeoutSeconds:
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                      type: object
+                    resources:
+                      description: 'Compute Resources required by this container.
+                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                      type: object
+                    securityContext:
+                      description: 'SecurityContext defines the security options the
+                        container should be run with. If set, the fields of SecurityContext
+                        override the equivalent fields of PodSecurityContext. More
+                        info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                      properties:
+                        allowPrivilegeEscalation:
+                          description: 'AllowPrivilegeEscalation controls whether
+                            a process can gain more privileges than its parent process.
+                            This bool directly controls if the no_new_privs flag will
+                            be set on the container process. AllowPrivilegeEscalation
+                            is true always when the container is: 1) run as Privileged
+                            2) has CAP_SYS_ADMIN Note that this field cannot be set
+                            when spec.os.name is windows.'
+                          type: boolean
+                        capabilities:
+                          description: The capabilities to add/drop when running containers.
+                            Defaults to the default set of capabilities granted by
+                            the container runtime. Note that this field cannot be
+                            set when spec.os.name is windows.
+                          properties:
+                            add:
+                              description: Added capabilities
+                              items:
+                                description: Capability represent POSIX capabilities
+                                  type
+                                type: string
+                              type: array
+                            drop:
+                              description: Removed capabilities
+                              items:
+                                description: Capability represent POSIX capabilities
+                                  type
+                                type: string
+                              type: array
+                          type: object
+                        privileged:
+                          description: Run container in privileged mode. Processes
+                            in privileged containers are essentially equivalent to
+                            root on the host. Defaults to false. Note that this field
+                            cannot be set when spec.os.name is windows.
+                          type: boolean
+                        procMount:
+                          description: procMount denotes the type of proc mount to
+                            use for the containers. The default is DefaultProcMount
+                            which uses the container runtime defaults for readonly
+                            paths and masked paths. This requires the ProcMountType
+                            feature flag to be enabled. Note that this field cannot
+                            be set when spec.os.name is windows.
+                          type: string
+                        readOnlyRootFilesystem:
+                          description: Whether this container has a read-only root
+                            filesystem. Default is false. Note that this field cannot
+                            be set when spec.os.name is windows.
+                          type: boolean
+                        runAsGroup:
+                          description: The GID to run the entrypoint of the container
+                            process. Uses runtime default if unset. May also be set
+                            in PodSecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence. Note that this field cannot be set when
+                            spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          description: Indicates that the container must run as a
+                            non-root user. If true, the Kubelet will validate the
+                            image at runtime to ensure that it does not run as UID
+                            0 (root) and fail to start the container if it does. If
+                            unset or false, no such validation will be performed.
+                            May also be set in PodSecurityContext.  If set in both
+                            SecurityContext and PodSecurityContext, the value specified
+                            in SecurityContext takes precedence.
+                          type: boolean
+                        runAsUser:
+                          description: The UID to run the entrypoint of the container
+                            process. Defaults to user specified in image metadata
+                            if unspecified. May also be set in PodSecurityContext.  If
+                            set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence. Note
+                            that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          description: The SELinux context to be applied to the container.
+                            If unspecified, the container runtime will allocate a
+                            random SELinux context for each container.  May also be
+                            set in PodSecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence. Note that this field cannot be set when
+                            spec.os.name is windows.
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies
+                                to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies
+                                to the container.
+                              type: string
+                          type: object
+                        seccompProfile:
+                          description: The seccomp options to use by this container.
+                            If seccomp options are provided at both the pod & container
+                            level, the container options override the pod options.
+                            Note that this field cannot be set when spec.os.name is
+                            windows.
+                          properties:
+                            localhostProfile:
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used. The profile
+                                must be preconfigured on the node to work. Must be
+                                a descending path, relative to the kubelet's configured
+                                seccomp profile location. Must only be set if type
+                                is "Localhost".
+                              type: string
+                            type:
+                              description: "type indicates which kind of seccomp profile
+                                will be applied. Valid options are: \n Localhost -
+                                a profile defined in a file on the node should be
+                                used. RuntimeDefault - the container runtime default
+                                profile should be used. Unconfined - no profile should
+                                be applied."
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        windowsOptions:
+                          description: The Windows specific settings applied to all
+                            containers. If unspecified, the options from the PodSecurityContext
+                            will be used. If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is
+                            linux.
+                          properties:
+                            gmsaCredentialSpec:
+                              description: GMSACredentialSpec is where the GMSA admission
+                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                inlines the contents of the GMSA credential spec named
+                                by the GMSACredentialSpecName field.
+                              type: string
+                            gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
+                              type: string
+                            hostProcess:
+                              description: HostProcess determines if a container should
+                                be run as a 'Host Process' container. This field is
+                                alpha-level and will only be honored by components
+                                that enable the WindowsHostProcessContainers feature
+                                flag. Setting this field without the feature flag
+                                will result in errors when validating the Pod. All
+                                of a Pod's containers must have the same effective
+                                HostProcess value (it is not allowed to have a mix
+                                of HostProcess containers and non-HostProcess containers).  In
+                                addition, if HostProcess is true then HostNetwork
+                                must also be set to true.
+                              type: boolean
+                            runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process. Defaults to the user specified
+                                in image metadata if unspecified. May also be set
+                                in PodSecurityContext. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              type: string
+                          type: object
+                      type: object
+                    startupProbe:
+                      description: 'StartupProbe indicates that the Pod has successfully
+                        initialized. If specified, no other probes are executed until
+                        this completes successfully. If this probe fails, the Pod
+                        will be restarted, just as if the livenessProbe failed. This
+                        can be used to provide different probe parameters at the beginning
+                        of a Pod''s lifecycle, when it might take a long time to load
+                        data or warm a cache, than during steady-state operation.
+                        This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        failureThreshold:
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        grpc:
+                          description: GRPC specifies an action involving a GRPC port.
+                            This is a beta field and requires enabling GRPCContainerProbe
+                            feature gate.
+                          properties:
+                            port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
+                              format: int32
+                              type: integer
+                            service:
+                              description: "Service is the name of the service to
+                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                \n If this is not specified, the default behavior
+                                is defined by gRPC."
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        initialDelaySeconds:
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                        periodSeconds:
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness and startup. Minimum value
+                            is 1.
+                          format: int32
+                          type: integer
+                        tcpSocket:
+                          description: TCPSocket specifies an action involving a TCP
+                            port.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs
+                            to terminate gracefully upon probe failure. The grace
+                            period is the duration in seconds after the processes
+                            running in the pod are sent a termination signal and the
+                            time when the processes are forcibly halted with a kill
+                            signal. Set this value longer than the expected cleanup
+                            time for your process. If this value is nil, the pod's
+                            terminationGracePeriodSeconds will be used. Otherwise,
+                            this value overrides the value provided by the pod spec.
+                            Value must be non-negative integer. The value zero indicates
+                            stop immediately via the kill signal (no opportunity to
+                            shut down). This is a beta field and requires enabling
+                            ProbeTerminationGracePeriod feature gate. Minimum value
+                            is 1. spec.terminationGracePeriodSeconds is used if unset.
+                          format: int64
+                          type: integer
+                        timeoutSeconds:
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                      type: object
+                    stdin:
+                      description: Whether this container should allocate a buffer
+                        for stdin in the container runtime. If this is not set, reads
+                        from stdin in the container will always result in EOF. Default
+                        is false.
+                      type: boolean
+                    stdinOnce:
+                      description: Whether the container runtime should close the
+                        stdin channel after it has been opened by a single attach.
+                        When stdin is true the stdin stream will remain open across
+                        multiple attach sessions. If stdinOnce is set to true, stdin
+                        is opened on container start, is empty until the first client
+                        attaches to stdin, and then remains open and accepts data
+                        until the client disconnects, at which time stdin is closed
+                        and remains closed until the container is restarted. If this
+                        flag is false, a container processes that reads from stdin
+                        will never receive an EOF. Default is false
+                      type: boolean
+                    terminationMessagePath:
+                      description: 'Optional: Path at which the file to which the
+                        container''s termination message will be written is mounted
+                        into the container''s filesystem. Message written is intended
+                        to be brief final status, such as an assertion failure message.
+                        Will be truncated by the node if greater than 4096 bytes.
+                        The total message length across all containers will be limited
+                        to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                      type: string
+                    terminationMessagePolicy:
+                      description: Indicate how the termination message should be
+                        populated. File will use the contents of terminationMessagePath
+                        to populate the container status message on both success and
+                        failure. FallbackToLogsOnError will use the last chunk of
+                        container log output if the termination message file is empty
+                        and the container exited with an error. The log output is
+                        limited to 2048 bytes or 80 lines, whichever is smaller. Defaults
+                        to File. Cannot be updated.
+                      type: string
+                    tty:
+                      description: Whether this container should allocate a TTY for
+                        itself, also requires 'stdin' to be true. Default is false.
+                      type: boolean
+                    volumeDevices:
+                      description: volumeDevices is the list of block devices to be
+                        used by the container.
+                      items:
+                        description: volumeDevice describes a mapping of a raw block
+                          device within a container.
+                        properties:
+                          devicePath:
+                            description: devicePath is the path inside of the container
+                              that the device will be mapped to.
+                            type: string
+                          name:
+                            description: name must match the name of a persistentVolumeClaim
+                              in the pod
+                            type: string
+                        required:
+                        - devicePath
+                        - name
+                        type: object
+                      type: array
+                    volumeMounts:
+                      description: Pod volumes to mount into the container's filesystem.
+                        Cannot be updated.
+                      items:
+                        description: VolumeMount describes a mounting of a Volume
+                          within a container.
+                        properties:
+                          mountPath:
+                            description: Path within the container at which the volume
+                              should be mounted.  Must not contain ':'.
+                            type: string
+                          mountPropagation:
+                            description: mountPropagation determines how mounts are
+                              propagated from the host to container and the other
+                              way around. When not set, MountPropagationNone is used.
+                              This field is beta in 1.10.
+                            type: string
+                          name:
+                            description: This must match the Name of a Volume.
+                            type: string
+                          readOnly:
+                            description: Mounted read-only if true, read-write otherwise
+                              (false or unspecified). Defaults to false.
+                            type: boolean
+                          subPath:
+                            description: Path within the volume from which the container's
+                              volume should be mounted. Defaults to "" (volume's root).
+                            type: string
+                          subPathExpr:
+                            description: Expanded path within the volume from which
+                              the container's volume should be mounted. Behaves similarly
+                              to SubPath but environment variable references $(VAR_NAME)
+                              are expanded using the container's environment. Defaults
+                              to "" (volume's root). SubPathExpr and SubPath are mutually
+                              exclusive.
+                            type: string
+                        required:
+                        - mountPath
+                        - name
+                        type: object
+                      type: array
+                    workingDir:
+                      description: Container's working directory. If not specified,
+                        the container runtime's default will be used, which might
+                        be configured in the container image. Cannot be updated.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              wireguardImage:
+                description: WireguardImage for wireguard k8s deployment
+                type: string
+            required:
+            - wireguardImage
+            type: object
+          status:
+            description: WireguardServerStatus defines the observed state of Wireguard
+            properties:
+              conditions:
+                description: Conditions defines current service state of the PacketMachine.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              hostname:
+                type: string
+              port:
+                type: string
+              ready:
+                description: Ready is true when the provider resource is ready.
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/bootstrap/helm/bootstrap/templates/rbac.yaml
+++ b/bootstrap/helm/bootstrap/templates/rbac.yaml
@@ -150,7 +150,7 @@ rules:
 - apiGroups:
   - vpn.plural.sh
   resources:
-  - wireguards
+  - wireguardservers
   verbs:
   - create
   - delete
@@ -162,13 +162,13 @@ rules:
 - apiGroups:
   - vpn.plural.sh
   resources:
-  - wireguards/finalizers
+  - wireguardservers/finalizers
   verbs:
   - update
 - apiGroups:
   - vpn.plural.sh
   resources:
-  - wireguards/status
+  - wireguardservers/status
   verbs:
   - get
   - patch

--- a/bootstrap/helm/bootstrap/templates/rbac.yaml
+++ b/bootstrap/helm/bootstrap/templates/rbac.yaml
@@ -121,6 +121,94 @@ rules:
   - watch
   - list
   - delete
+- apiGroups:
+  - vpn.plural.sh
+  resources:
+  - wireguardpeers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - vpn.plural.sh
+  resources:
+  - wireguardpeers/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - vpn.plural.sh
+  resources:
+  - wireguardpeers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - vpn.plural.sh
+  resources:
+  - wireguards
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - vpn.plural.sh
+  resources:
+  - wireguards/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - vpn.plural.sh
+  resources:
+  - wireguards/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 ---
 # permissions to do leader election.
 apiVersion: rbac.authorization.k8s.io/v1

--- a/bootstrap/helm/bootstrap/values.yaml
+++ b/bootstrap/helm/bootstrap/values.yaml
@@ -35,7 +35,7 @@ pluralToken: plrl-api-token
 plural:
   image:
     repository: dkr.plural.sh/bootstrap/plural-operator
-    tag: 0.5.0
+    tag: 0.5.1
 
 imagePullSecrets:
 - name: plural-creds

--- a/bootstrap/helm/bootstrap/values.yaml
+++ b/bootstrap/helm/bootstrap/values.yaml
@@ -35,7 +35,7 @@ pluralToken: plrl-api-token
 plural:
   image:
     repository: dkr.plural.sh/bootstrap/plural-operator
-    tag: 0.4.0
+    tag: 0.5.0
 
 imagePullSecrets:
 - name: plural-creds


### PR DESCRIPTION
## Summary
This PR updates the bootstrap helm chart to use the latest plural operator that includes the ability to create a Wireguard VPN and add peers to the VPN.


## Test Plan
Local linking.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP