### PR TITLE
Add SMTP settings to Grafana

### DIFF
--- a/grafana/helm/grafana/Chart.yaml
+++ b/grafana/helm/grafana/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: grafana
 description: A Helm chart for grafana on plural
 type: application
-version: 0.2.15
-appVersion: "9.2.2"
+version: 0.2.16
+appVersion: "9.2.3"
 dependencies:
 - name: grafana
   version: 6.43.2

--- a/grafana/helm/grafana/templates/smtp-secret.yaml
+++ b/grafana/helm/grafana/templates/smtp-secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.secret.smtp.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-smtp-credentials
+  labels:
+{{ include "grafana-plural.labels" . | indent 4 }}
+type: Opaque
+data:
+  user: {{ .Values.secret.smtp.user | b64enc | quote }}
+  password: {{ .Values.secret.smtp.password | b64enc | quote }}
+{{- end }}

--- a/grafana/helm/grafana/values.yaml
+++ b/grafana/helm/grafana/values.yaml
@@ -8,13 +8,19 @@ test-base:
   testName: grafana-integration
   promoteTag: warm
 
+secret:
+  smtp:
+    enabled: false
+    user: ""
+    password: ""
+
 grafana:
   rbac:
     pspEnabled: false
 
   image:
     repository: dkr.plural.sh/grafana/grafana/grafana
-    tag: 9.2.2
+    tag: 9.2.3
   initChownData:
     image:
       repository: gcr.io/pluralsh/library/busybox

--- a/grafana/helm/grafana/values.yaml.tpl
+++ b/grafana/helm/grafana/values.yaml.tpl
@@ -40,7 +40,7 @@ grafana:
     smtp:
       enabled: true
       host: "{{ .SMTP.Server }}:{{ .SMTP.Port }}"
-      from_address: {{ .SMTP.Sender }}∂
+      from_address: {{ .SMTP.Sender }}
     {{- end }}
     {{- if .OIDC }}
     auth.generic_oauth:

--- a/grafana/helm/grafana/values.yaml.tpl
+++ b/grafana/helm/grafana/values.yaml.tpl
@@ -4,6 +4,14 @@ global:
     - description: grafana web ui
       url: {{ .Values.hostname }}
 
+{{- if .SMTP }}
+secret:
+  smtp:
+    enabled: true
+    user: {{ .SMTP.User }}
+    password: {{ .SMTP.Password }}
+{{- end }}
+
 grafana:
   admin:
     password: {{ dedupe . "grafana.grafana.admin.password" (randAlphaNum 14) }}
@@ -19,10 +27,22 @@ grafana:
       secretName: grafana-tls
     hosts:
     - {{ .Values.hostname }}
-  {{ if .OIDC }}
+  {{- if .SMTP }}
+  smtp:
+    existingSecret: grafana-smtp-credentials
+    userKey: "user"
+    passwordKey: "password"
+  {{- end }}
   grafana.ini:
     server:
       root_url: https://{{ .Values.hostname }}
+    {{- if .SMTP }}
+    smtp:
+      enabled: true
+      host: "{{ .SMTP.Server }}:{{ .SMTP.Port }}"
+      from_address: {{ .SMTP.Sender }}∂
+    {{- end }}
+    {{- if .OIDC }}
     auth.generic_oauth:
       name: Plural
       enabled: true
@@ -35,7 +55,7 @@ grafana:
       api_url: {{ .OIDC.Configuration.UserinfoEndpoint }}
       role_attribute_path: "null"
       groups_attribute_path: groups
-  {{ end }}
+    {{- end }}
   {{- if .Configuration.loki }}
   datasources:
     datasources.yaml:


### PR DESCRIPTION
## Summary
Adds SMTP settings to Grafana so that users can be invited.


## Test Plan
Local linking

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP