### PR TITLE
Adding docker-in-docker container into jitsu deployment

### DIFF
--- a/jitsu/helm/jitsu/Chart.yaml
+++ b/jitsu/helm/jitsu/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: jitsu
 description: helm chart for jitsu
 type: application
-version: 0.1.16
+version: 0.1.17
 appVersion: 1.41.5

--- a/jitsu/helm/jitsu/templates/deployment.yaml
+++ b/jitsu/helm/jitsu/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
         {{- if .Values.airbyte.enabled }}
         - name: dind-daemon
-          image: docker:dind
+          image: {{ .Values.airbyte.dindImage }}
           command: [ "dockerd", "--host", "tcp://127.0.0.1:2375" ]
           securityContext:
             privileged: true

--- a/jitsu/helm/jitsu/templates/deployment.yaml
+++ b/jitsu/helm/jitsu/templates/deployment.yaml
@@ -28,11 +28,13 @@ spec:
       serviceAccountName: {{ include "jitsu.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.airbyte.enabled }}
       volumes:
         - name: docker-graph-storage
           emptyDir: {}
         - name: jitsu-workspace
           emptyDir: {}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -42,9 +44,11 @@ spec:
           envFrom:
             - secretRef:
                 name: jitsu-env
+          {{- if .Values.airbyte.enabled }}
           volumeMounts:
             - name: jitsu-workspace
               mountPath: /home/eventnative/data/airbyte
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.containerPort }}
@@ -65,6 +69,7 @@ spec:
             periodSeconds: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        {{- if .Values.airbyte.enabled }}
         - name: dind-daemon
           image: docker:dind
           command: [ "dockerd", "--host", "tcp://127.0.0.1:2375" ]
@@ -75,6 +80,7 @@ spec:
               mountPath: /var/lib/docker
             - name: jitsu-workspace
               mountPath: /tmp/airbyte
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/jitsu/helm/jitsu/templates/deployment.yaml
+++ b/jitsu/helm/jitsu/templates/deployment.yaml
@@ -57,6 +57,11 @@ spec:
             periodSeconds: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        - name: dind-daemon
+          image: docker:dind
+          command: [ "dockerd", "--host", "tcp://127.0.0.1:2375" ]
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/jitsu/helm/jitsu/templates/deployment.yaml
+++ b/jitsu/helm/jitsu/templates/deployment.yaml
@@ -28,6 +28,11 @@ spec:
       serviceAccountName: {{ include "jitsu.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        - name: docker-graph-storage
+          emptyDir: {}
+        - name: jitsu-workspace
+          emptyDir: {}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -37,6 +42,9 @@ spec:
           envFrom:
             - secretRef:
                 name: jitsu-env
+          volumeMounts:
+            - name: jitsu-workspace
+              mountPath: /home/eventnative/data/airbyte
           ports:
             - name: http
               containerPort: {{ .Values.service.containerPort }}
@@ -61,7 +69,12 @@ spec:
           image: docker:dind
           command: [ "dockerd", "--host", "tcp://127.0.0.1:2375" ]
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            privileged: true
+          volumeMounts:
+            - name: docker-graph-storage
+              mountPath: /var/lib/docker
+            - name: jitsu-workspace
+              mountPath: /tmp/airbyte
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/jitsu/helm/jitsu/templates/secret.yaml
+++ b/jitsu/helm/jitsu/templates/secret.yaml
@@ -15,8 +15,10 @@ stringData:
   {{ if .Values.secrets.smtp }}
   JITSU_SMTP_CONFIG: {{ toJson .Values.secrets.smtp | quote }}
   {{ end }}
+  {{- if .Values.airbyte.enabled }}
   DOCKER_HOST: tcp://localhost:2375
   SERVER_VOLUMES_WORKSPACE: /tmp/airbyte/
+  {{ end }}
 ---
 apiVersion: v1
 kind: Secret

--- a/jitsu/helm/jitsu/templates/secret.yaml
+++ b/jitsu/helm/jitsu/templates/secret.yaml
@@ -15,6 +15,8 @@ stringData:
   {{ if .Values.secrets.smtp }}
   JITSU_SMTP_CONFIG: {{ toJson .Values.secrets.smtp | quote }}
   {{ end }}
+  DOCKER_HOST: tcp://localhost:2375
+  SERVER_VOLUMES_WORKSPACE: /tmp/airbyte/
 ---
 apiVersion: v1
 kind: Secret

--- a/jitsu/helm/jitsu/values.yaml
+++ b/jitsu/helm/jitsu/values.yaml
@@ -84,8 +84,11 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+# Access to additional sources through the airbyte.
+# It works with help of the Docker-In-Docker daemon.
 airbyte:
   enabled: false
+  dindImage: docker:dind
 
 nodeSelector: {}
 

--- a/jitsu/helm/jitsu/values.yaml
+++ b/jitsu/helm/jitsu/values.yaml
@@ -84,6 +84,9 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+airbyte:
+  enabled: false
+
 nodeSelector: {}
 
 tolerations: []

--- a/jitsu/helm/jitsu/values.yaml.tpl
+++ b/jitsu/helm/jitsu/values.yaml.tpl
@@ -5,6 +5,9 @@ global:
     - description: jitsu web ui
       url: {{ .Values.hostname }}
 
+airbyte:
+  enabled: {{ .Values.airbyte.enabled }}
+
 ingress:
   host: {{ .Values.hostname }}
   apiHost: {{ .Values.apiHostname }}


### PR DESCRIPTION
Summary:
Adding docker-in-docker-daemon.
It helps **jitsu** to get access to sources through **airbyte**

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP