### PR TITLE
Bump grafana to 9.2.4 to fix security vuln

### DIFF
--- a/grafana/helm/grafana/Chart.yaml
+++ b/grafana/helm/grafana/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: grafana
 description: A Helm chart for grafana on plural
 type: application
-version: 0.2.17
-appVersion: "9.2.3"
+version: 0.2.18
+appVersion: "9.2.4"
 dependencies:
 - name: grafana
   version: 6.43.2

--- a/grafana/helm/grafana/values.yaml
+++ b/grafana/helm/grafana/values.yaml
@@ -29,7 +29,7 @@ grafana:
 
   image:
     repository: dkr.plural.sh/grafana/grafana/grafana
-    tag: 9.2.3
+    tag: 9.2.4
   initChownData:
     image:
       repository: gcr.io/pluralsh/library/busybox


### PR DESCRIPTION
## Summary

There's a severe vulnerability in grafana pre 9.2.4 that we need to patch

Closes #434

## Test Plan
local link


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP