### PR TITLE
Bump airbyte to 0.39.42

### DIFF
--- a/airbyte/helm/airbyte/Chart.yaml
+++ b/airbyte/helm/airbyte/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: airbyte
 description: Unified data integration platform
 type: application
-version: 0.2.31
-appVersion: 0.39.14-alpha
+version: 0.2.32
+appVersion: 0.39.42-alpha
 dependencies:
 - name: airbyte
   version: 0.3.0

--- a/airbyte/helm/airbyte/values.yaml
+++ b/airbyte/helm/airbyte/values.yaml
@@ -168,7 +168,7 @@ configOverlays:
             ]
 
 airbyte:
-  version: 0.39.14-alpha
+  version: 0.39.42-alpha
 
   postgresql:
     enabled: false
@@ -196,11 +196,11 @@ airbyte:
 
   bootloader:
     image:
-      tag: 0.39.14-alpha
+      tag: 0.39.42-alpha
 
   worker:
     image:
-      tag: 0.39.14-alpha
+      tag: 0.39.42-alpha
 
   scheduler:
     image:
@@ -208,11 +208,11 @@ airbyte:
 
   server:
     image:
-      tag: 0.39.14-alpha
+      tag: 0.39.42-alpha
 
   webapp:
     image:
-      tag: 0.39.14-alpha
+      tag: 0.39.42-alpha
 
     ingress:
       enabled: false


### PR DESCRIPTION
## Summary

This allows us to support otel properly and should have been done regardless


## Test Plan
local link, confirmed a sync can be started


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP