### PR TITLE
Vault private ingress

### DIFF
--- a/vault/helm/vault/runbooks/scaling-manual.xml
+++ b/vault/helm/vault/runbooks/scaling-manual.xml
@@ -1,0 +1,105 @@
+<root gap='medium'>
+    <box pad='small' gap='medium' direction='row' align='center'>
+        <button label='Scale' action='scale' primary='true' headline='true' />
+        <box direction='row' align='center' gap='small'>
+            <box gap='small' align='center'>
+                <timeseries datasource="vault-web-cpu" label="Vault Web CPU Usage" />
+                <text size='small'>You should set a requests to
+                    roughly correspond to 80% regular utilization</text>
+                <text size='small'>Normally a CPU limit is not required</text>
+            </box>
+            <box gap='small' align='center'>
+                <timeseries datasource="vault-web-memory" label="Vault Web Memory Usage" />
+                <text size='small'>You should set a requests to
+                    roughly correspond to 80% regular utilization</text>
+                <text size='small'>A memory limit should be set to avoid resource starvation</text>
+            </box>
+        </box>
+        <box gap='xsmall'>
+            <box gap='xsmall'>
+                <input placeholder="250m" label='Vault Web CPU Request' name='vault-web-cpu'>
+                    <valueFrom
+                            datasource="vault"
+                            doc="kubernetes.raw"
+                            path="spec.template.spec.containers[0].resources.requests.cpu" />
+                </input>
+                <input placeholder="1Gi" label='Vault Web Memory Request' name='vault-web-memory'>
+                    <valueFrom
+                            datasource="vault"
+                            doc="kubernetes.raw"
+                            path="spec.template.spec.containers[0].resources.requests.memory" />
+                </input>
+            </box>
+            <box gap='xsmall'>
+                <input placeholder="250m" label='Vault Web CPU Limit' name='vault-web-cpu-limit'>
+                    <valueFrom
+                            datasource="vault"
+                            doc="kubernetes.raw"
+                            path="spec.template.spec.containers[0].resources.limits.cpu" />
+                </input>
+                <input placeholder="1Gi" label='Vault Web Memory Limit' name='vault-web-memory-limit'>
+                    <valueFrom
+                            datasource="vault"
+                            doc="kubernetes.raw"
+                            path="spec.template.spec.containers[0].resources.limits.memory" />
+                </input>
+            </box>
+        </box>
+    </box>
+    <box pad='small' gap='medium' direction='row' align='center'>
+        <box direction='row' align='center' gap='small'>
+            <box gap='small' align='center'>
+                <timeseries datasource="vault-injector-cpu" label="Vault Injector CPU Usage" />
+                <text size='small'>You should set a requests to
+                    roughly correspond to 80% regular utilization</text>
+                <text size='small'>Normally a CPU limit is not required</text>
+            </box>
+            <box gap='small' align='center'>
+                <timeseries datasource="vault-injector-memory" label="Vault Injector Memory Usage" />
+                <text size='small'>You should set a requests to
+                    roughly correspond to 80% regular utilization</text>
+                <text size='small'>A memory limit should be set to avoid resource starvation</text>
+            </box>
+        </box>
+        <box gap='xsmall'>
+            <box gap='xsmall'>
+                <input placeholder="250m" label='Vault Injector  CPU Request' name='vault-injector-cpu'>
+                    <valueFrom
+                            datasource="vault-injector"
+                            doc="kubernetes.raw"
+                            path="spec.template.spec.containers[0].resources.requests.cpu" />
+                </input>
+                <input placeholder="1Gi" label='Vault Injector Memory Request' name='vault-injector-memory'>
+                    <valueFrom
+                            datasource="vault-injector"
+                            doc="kubernetes.raw"
+                            path="spec.template.spec.containers[0].resources.requests.memory" />
+                </input>
+            </box>
+            <box gap='xsmall'>
+                <input placeholder="250m" label='Vault Injector CPU Limit' name='vault-injector-cpu-limit'>
+                    <valueFrom
+                            datasource="vault-injector"
+                            doc="kubernetes.raw"
+                            path="spec.template.spec.containers[0].resources.limits.cpu" />
+                </input>
+                <input placeholder="1Gi" label='Vault Injector Memory Limit' name='vault-injector-memory-limit'>
+                    <valueFrom
+                            datasource="vault-injector"
+                            doc="kubernetes.raw"
+                            path="spec.template.spec.containers[0].resources.limits.memory" />
+                </input>
+                <input placeholder="1" label='Vault Injector Replicas' name='vault-injector-replicas'>
+                    <valueFrom
+                            datasource="vault-injector"
+                            doc="kubernetes.raw"
+                            path="spec.replicas" />
+                </input>
+            </box>
+        </box>
+    </box>
+    <box width='100%' gap='small'>
+        <text size='small'>Be sure to scale your Vault components within the capacity of your nodes.</text>
+        <text size='small'>By default this is a maximum of 8 CPU and 32 Gi memory.</text>
+    </box>
+</root>

--- a/vault/helm/vault/templates/runbooks.yaml
+++ b/vault/helm/vault/templates/runbooks.yaml
@@ -1,0 +1,119 @@
+apiVersion: platform.plural.sh/v1alpha1
+kind: Runbook
+metadata:
+  name: scaling-manual
+  labels:
+    platform.plural.sh/pinned: 'true'
+{{ include "vault-plural.labels" . | indent 4 }}
+spec:
+  name: Vault Scaling
+  description: overview of how to optimally scale your Vault cluster
+  display: |-
+{{ .Files.Get "runbooks/scaling-manual.xml" | indent 4 }}
+  datasources:
+  - name: vault-web-cpu
+    type: prometheus
+    prometheus:
+      format: cpu
+      legend: $pod
+      query: sum(rate(container_cpu_usage_seconds_total{namespace="{{ .Release.Namespace }}",pod=~"vault-[0-9]"}[5m])) by (pod)
+  - name: vault-web-memory
+    type: prometheus
+    prometheus:
+      format: memory
+      legend: $pod
+      query: sum(container_memory_working_set_bytes{namespace="{{ .Release.Namespace }}",pod=~"vault-[0-9]"}) by (pod)
+  - name: vault-injector-cpu
+    type: prometheus
+    prometheus:
+      format: cpu
+      legend: $pod
+      query: sum(rate(container_cpu_usage_seconds_total{namespace="{{ .Release.Namespace }}",pod=~"vault-agent-injector.+"}[5m])) by (pod)
+  - name: vault-injector-memory
+    type: prometheus
+    prometheus:
+      format: memory
+      legend: $pod
+      query: sum(container_memory_working_set_bytes{namespace="{{ .Release.Namespace }}",pod=~"vault-agent-injector.+"}) by (pod)
+  - name: vault
+    type: kubernetes
+    kubernetes:
+      resource: statefulset
+      name: vault
+  - name: vault-injector
+    type: kubernetes
+    kubernetes:
+      resource: deployment
+      name: vault-agent-injector
+  - name: nodes
+    type: nodes
+  actions:
+  - name: scale
+    action: config
+    redirectTo: '/'
+    configuration:
+      updates:
+        - path:
+            - chatwoot
+            - chatwoot
+            - web
+            - resources
+            - requests
+            - cpu
+          valueFrom: chatwoot-web-cpu
+        - path:
+            - chatwoot
+            - chatwoot
+            - web
+            - resources
+            - requests
+            - memory
+          valueFrom: chatwoot-web-memory
+        - path:
+            - chatwoot
+            - chatwoot
+            - web
+            - resources
+            - limits
+            - cpu
+          valueFrom: chatwoot-web-cpu-limit
+        - path:
+            - chatwoot
+            - chatwoot
+            - web
+            - resources
+            - limits
+            - memory
+          valueFrom: chatwoot-web-memory-limit
+        - path:
+            - chatwoot
+            - chatwoot
+            - worker
+            - resources
+            - requests
+            - cpu
+          valueFrom: chatwoot-worker-cpu
+        - path:
+            - chatwoot
+            - chatwoot
+            - worker
+            - resources
+            - requests
+            - memory
+          valueFrom: chatwoot-worker-memory
+        - path:
+            - chatwoot
+            - chatwoot
+            - worker
+            - resources
+            - limits
+            - cpu
+          valueFrom: chatwoot-worker-cpu-limit
+        - path:
+            - chatwoot
+            - chatwoot
+            - worker
+            - resources
+            - limits
+            - memory
+          valueFrom: chatwoot-worker-memory-limit

--- a/vault/helm/vault/values.yaml
+++ b/vault/helm/vault/values.yaml
@@ -2,11 +2,12 @@ vault:
   injector:
     resources:
       requests:
-        memory: 256Mi
-        cpu: 250m
+        memory: 32Mi
+        cpu: 0.1m
       limits:
-        memory: 256Mi
-  
+        cpu: 0.2m
+        memory: 48Mi
+
   server:
     image:
       repository: "davidspek/vault"
@@ -18,10 +19,11 @@ vault:
     # Reference Architecture for a Small Cluster
     resources:
       requests:
-        memory: 1Gi
-        cpu: 500m
+        memory: 64Mi
+        cpu: 0.1m
       limits:
-        memory: 16Gi
+        cpu: 0.2m
+        memory: 96Mi
 
     volumes:
     - name: policies

--- a/vault/helm/vault/values.yaml.tpl
+++ b/vault/helm/vault/values.yaml.tpl
@@ -43,7 +43,11 @@ vault:
         cert-manager.io/cluster-issuer: letsencrypt-prod
         nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
         nginx.ingress.kubernetes.io/use-regex: "true"
+      {{- if not .Values.exposePrivate }}
       ingressClassName: nginx
+      {{- else }}
+      ingressClassName: internal-nginx
+      {{- end }}
       hosts:
       - host: {{ .Values.hostname }}
         paths: []

--- a/vault/plural/recipes/vault-aws.yaml
+++ b/vault/plural/recipes/vault-aws.yaml
@@ -18,6 +18,10 @@ sections:
   - name: hostname
     documentation: FQDN to use for your Vault installation
     type: DOMAIN
+  - name: exposePrivate
+    documentation: Should vault only be exposed on the internal network?
+    type: BOOL
+    default: false
   items:
   - type: TERRAFORM
     name: aws


### PR DESCRIPTION
## Summary
Changes on this PR:
- Private ingress  added for Vault deployment
- Runbooks 
- CPU/Memory requests and limits set 



## Test Plan
- Runbooks corectly displayed in Console
- Pods are starting with new requests and limits
- If exposePrivate flag is set to true, Vault UI is available only when using VPN connection to EKS cluster 


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [X]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [X]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [X]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [X]  Azure
    - [ ]  AWS
    - [ ]  GCP