### PR TITLE
Add smtp setup for n8n

### DIFF
--- a/n8n/helm/n8n/Chart.yaml
+++ b/n8n/helm/n8n/Chart.yaml
@@ -3,7 +3,7 @@ name: n8n
 description: helm chart for n8n
 type: application
 version: 0.1.5
-appVersion: "0.181.2"
+appVersion: "0.202.1"
 dependencies:
 - name: postgres
   version: 0.1.10

--- a/n8n/helm/n8n/Chart.yaml
+++ b/n8n/helm/n8n/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: n8n
 description: helm chart for n8n
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "0.181.2"
 dependencies:
 - name: postgres

--- a/n8n/helm/n8n/templates/deployment.yaml
+++ b/n8n/helm/n8n/templates/deployment.yaml
@@ -40,6 +40,11 @@ spec:
             - name: http
               containerPort: 5678
               protocol: TCP
+          {{- if .Values.smtp }}
+          envFrom:
+            - secretRef:
+                name: n8n-smtp
+          {{- end }}
           env:
             - name: "N8N_PORT"
               value: "5678"

--- a/n8n/helm/n8n/templates/deployment.yaml
+++ b/n8n/helm/n8n/templates/deployment.yaml
@@ -58,6 +58,8 @@ spec:
               value: {{ .Values.database.port | quote }}
             - name: DB_POSTGRESDB_SSL_REJECT_UNAUTHORIZED
               value: "false"
+            - name: WEBHOOK_URL
+              value: {{ .Values.webhookUrl }}
             - name: DB_POSTGRESDB_USER
               valueFrom:
                 secretKeyRef:

--- a/n8n/helm/n8n/templates/secret.yaml
+++ b/n8n/helm/n8n/templates/secret.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.smtp }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: n8n-smtp
+  labels:
+{{ include "n8n.labels" . | indent 4 }}
+stringData:
+  N8N_SMTP_HOST: {{ .Values.smtp.host | quote }}
+  N8N_SMTP_USER: {{ .Values.smtp.user | quote }}
+  N8N_SMTP_PASS: {{ .Values.smtp.password | quote }}
+  N8N_SMTP_PORT: {{ .Values.smtp.port | quote }}
+  N8N_SMTP_SENDER: {{ .Values.smtp.sender | quote }}
+{{- end }}

--- a/n8n/helm/n8n/values.yaml
+++ b/n8n/helm/n8n/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: dkr.plural.sh/n8n/n8nio/n8n
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.181.2"
+  tag: "0.202.1"
 
 smtp:
 

--- a/n8n/helm/n8n/values.yaml
+++ b/n8n/helm/n8n/values.yaml
@@ -10,6 +10,8 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "0.181.2"
 
+smtp:
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/n8n/helm/n8n/values.yaml.tpl
+++ b/n8n/helm/n8n/values.yaml.tpl
@@ -4,6 +4,15 @@ global:
     - description: n8n web ui
       url: {{ .Values.hostname }}
 
+{{ if .SMTP }}
+smtp:
+  host: {{ .SMTP.Server }}
+  user: {{ .SMTP.User }}
+  password: {{ .SMTP.Password }}
+  port: {{ .SMTP.Port }}
+  sender: {{ .SMTP.Sender }}
+{{ end }}
+
 ingress:
   hosts:
    - host: {{ .Values.hostname }}


### PR DESCRIPTION
## Summary

add ability to read smtp config and store them in an env secret

## Test Plan
local link


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP