### PR TITLE
Add customizable pod sweeper setup

### DIFF
--- a/airbyte/helm/airbyte/Chart.yaml
+++ b/airbyte/helm/airbyte/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: airbyte
 description: Unified data integration platform
 type: application
-version: 0.2.32
+version: 0.2.33
 appVersion: 0.39.42-alpha
 dependencies:
 - name: airbyte

--- a/airbyte/helm/airbyte/charts/airbyte/templates/pod-sweeper/configmap.yaml
+++ b/airbyte/helm/airbyte/charts/airbyte/templates/pod-sweeper/configmap.yaml
@@ -5,4 +5,4 @@ metadata:
   name: {{ include "airbyte.fullname" . }}-sweep-pod-script
 data:
   sweep-pod.sh: |
-  {{- (.Files.Get "files/sweep-pod.sh") | nindent 4 }}
+    {{ include "airbyte.sweeper" . | nindent 4 }}

--- a/airbyte/helm/airbyte/charts/airbyte/templates/pod-sweeper/sweeper-helpers.tpl
+++ b/airbyte/helm/airbyte/charts/airbyte/templates/pod-sweeper/sweeper-helpers.tpl
@@ -1,0 +1,42 @@
+{{- define "airbyte.sweeper" -}}
+#!/bin/bash
+
+get_worker_pods () {
+    kubectl -n ${KUBE_NAMESPACE} -L airbyte -l airbyte=worker-pod --field-selector status.phase!=Running get pods -o go-template --template '{{ .Values.podSweeper.podTemplate }}'
+}
+
+delete_worker_pod() {
+    printf "From status '%s' since '%s', " $2 $3
+    echo "$1" | grep -v "STATUS" | awk '{print $1}' | xargs --no-run-if-empty kubectl -n ${KUBE_NAMESPACE} delete pod
+}
+
+while :
+do
+    # Shorter time window for completed pods
+    SUCCESS_DATE_STR=`date -d 'now - {{ .Values.podSweeper.timeouts.success }}' --utc -Ins`
+    SUCCESS_DATE=`date -d $SUCCESS_DATE_STR +%s`
+    # Longer time window for pods in error (to debug)
+    NON_SUCCESS_DATE_STR=`date -d 'now - {{ .Values.podSweeper.timeouts.failure }}' --utc -Ins`
+    NON_SUCCESS_DATE=`date -d $NON_SUCCESS_DATE_STR +%s`
+    (
+        IFS=$'\n'
+        for POD in `get_worker_pods`; do
+            IFS=' '
+            POD_NAME=`echo $POD | cut -d " " -f 1`
+            POD_STATUS=`echo $POD | cut -d " " -f 2`
+            POD_DATE_STR=`echo $POD | cut -d " " -f 3`
+            POD_DATE=`date -d $POD_DATE_STR '+%s'`
+            if [ "$POD_STATUS" = "Succeeded" ]; then
+            if [ "$POD_DATE" -lt "$SUCCESS_DATE" ]; then
+                delete_worker_pod "$POD_NAME" "$POD_STATUS" "$POD_DATE_STR"
+            fi
+            else
+            if [ "$POD_DATE" -lt "$NON_SUCCESS_DATE" ]; then
+                delete_worker_pod "$POD_NAME" "$POD_STATUS" "$POD_DATE_STR"
+            fi
+            fi
+        done
+    )
+    sleep 60
+done
+{{- end -}}

--- a/airbyte/helm/airbyte/charts/airbyte/values.yaml
+++ b/airbyte/helm/airbyte/charts/airbyte/values.yaml
@@ -12,6 +12,7 @@ airbyteS3Region: ''
 
 extraEnv: []
 
+
 ## @section Common Parameters
 
 ## @param nameOverride String to partially override airbyte.fullname template with a string (will prepend the release name)
@@ -226,7 +227,13 @@ podSweeper:
 
   ## @param podSweeper.podAnnotations [object] Add extra annotations to the podSweeper pod
   ##
-  podAnnotations: {}
+  podAnnotations:
+    component-vsn: '2'
+
+  timeouts:
+    success: '2 hours'
+    failure: '24 hours'
+  podTemplate: '{{range .items}} {{.metadata.name}} {{.status.phase}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}'
 
   ## Pod Sweeper app resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
Adds the ability to modify the pod sweeper timeouts for your airbyte instance with:

```
airbyte:
  podSweeper:
    timeouts:
      success: ...
      failure: ...
```

We should probably find a way to deprecate this script entirely though as it's somewhat crap

<!--- Hello Plural contributor! It's great to have you with us! -->


## Test Plan
verified in a local link


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP