### PR TITLE
Fix log4j configuration on airbyte

### DIFF
--- a/airbyte/helm/airbyte/Chart.yaml
+++ b/airbyte/helm/airbyte/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: airbyte
 description: Unified data integration platform
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: 0.40.18
 dependencies:
 - name: airbyte

--- a/airbyte/helm/airbyte/charts/airbyte/templates/env-secret.yaml
+++ b/airbyte/helm/airbyte/charts/airbyte/templates/env-secret.yaml
@@ -27,9 +27,9 @@ stringData:
   {{ else }}
   STATE_STORAGE_S3_BUCKET_NAME: {{ .Values.airbyteS3Bucket | quote }}
   {{ end }}
+  GCS_LOG_BUCKET: {{ default "" .Values.airbyteGCSBucket | quote }}
   {{ if .Values.airbyteGCSBucket }}
   GCP_STORAGE_BUCKET: {{ default "" .Values.airbyteGCSBucket | quote }}
-  GCS_LOG_BUCKET: {{ default "" .Values.airbyteGCSBucket | quote }}
   {{ end }}
   GOOGLE_APPLICATION_CREDENTIALS: {{ default "" .Values.googleApplicationCredentials | quote }}
   INTERNAL_API_HOST: {{ include "common.names.fullname" . }}-server:{{ .Values.server.service.port }}
@@ -64,8 +64,8 @@ stringData:
   {{- end }}
   RUN_DATABASE_MIGRATION_ON_STARTUP: "true"
   S3_LOG_BUCKET: {{ default "" .Values.airbyteS3Bucket | quote }}
+  S3_LOG_BUCKET_REGION: {{ default "" .Values.airbyteS3Region | quote }}
   {{ if .Values.airbyteS3Region }}
-  S3_LOG_BUCKET_REGION: {{ .Values.airbyteS3Region | quote }}
   STATE_STORAGE_S3_REGION: {{ .Values.airbyteS3Region | quote }}
   STATE_STORAGE_S3_BUCKET_REGION: {{ .Values.airbyteS3Region | quote }}
   {{ end }}


### PR DESCRIPTION
## Summary

Some env vars being present but empty are significant in log4j setup in airbyte due to misconfigured defaults, as defined here: https://github.com/airbytehq/airbyte/blob/master/airbyte-commons/src/main/resources/log4j2.xml

Change how we default the env vars to not hit that footgun

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP