### PR TITLE
Update azure blob storage settings and set allow_nested_items_to_be_public to false

### DIFF
--- a/minio/terraform/azure/main.tf
+++ b/minio/terraform/azure/main.tf
@@ -15,6 +15,7 @@ data "azurerm_resource_group" "group" {
 data "azurerm_storage_account" "main" {
   name                     = var.storage_account_name
   resource_group_name      = data.azurerm_resource_group.group.name
+  allow_nested_items_to_be_public = false
 }
 
 resource "kubernetes_secret" "minio_azure_secret" {


### PR DESCRIPTION
## Summary
Update blob storage terraform resource and set allow_nested_items_to_be_public to false.

All the blobs that are created are not public. This is simply a setting to avoid any application creating a public blob by mistake. Its a requirement for our SOC2 process that all blob accounts have this set to false. 