### PR TITLE
fix(ghost): use correct vendored image and bump version

### DIFF
--- a/ghost/helm/ghost/Chart.yaml
+++ b/ghost/helm/ghost/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ghost
 description: A Helm chart for Kubernetes
 type: application
-version: 0.2.11
-appVersion: "5.2.0"
+version: 0.2.12
+appVersion: "5.24.1"

--- a/ghost/helm/ghost/values.yaml
+++ b/ghost/helm/ghost/values.yaml
@@ -7,8 +7,8 @@ db:
   username: ghost
 
 image:
-  repository: dkr.plural.sh/ghost/ghost
-  tag: 5.2-alpine
+  repository: dkr.plural.sh/ghost/library/ghost
+  tag: 5.24.1-alpine
   pullPolicy: IfNotPresent
 
 resources: {}


### PR DESCRIPTION
## Summary
This PR uses the newly vendored image for Ghost and bumps the image version. In the future, when a new version of Ghost is pushed Renovate should create a PR to update it.


## Test Plan
Local linking.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP