### PR TITLE
Add google ACME issuer

### DIFF
--- a/bootstrap/helm/bootstrap/templates/plural-issuer.yaml
+++ b/bootstrap/helm/bootstrap/templates/plural-issuer.yaml
@@ -1,0 +1,32 @@
+{{ if .Values.acme }}
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: plural
+  labels:
+{{ include "bootstrap.labels" . | indent 4 }}
+spec:
+  acme:
+    email: {{ .Values.ownerEmail }}
+    server: https://dv.acme-v02.api.pki.goog/directory
+    externalAccountBinding:
+      keyID: {{ .Values.acme.kid }}
+      keySecretRef:
+        name: plural-eab-secret
+        key: eab-secret
+      keyAlgorithm: HS256
+    privateKeySecretRef:
+      name: plural-cert-manager-key
+    solvers:
+    - dns01:
+      {{ .Values.dnsSolver | toYaml | nindent 8 }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: plural-eab-secret
+  labels:
+{{ include "bootstrap.labels" . | indent 4 }}
+stringData:
+  eab-secret: {{ .Values.acme.secret }}
+{{ end }}

--- a/bootstrap/helm/bootstrap/values.yaml
+++ b/bootstrap/helm/bootstrap/values.yaml
@@ -1,3 +1,5 @@
+acme:
+
 external-dns:
   serviceAccount:
     name: external-dns

--- a/bootstrap/helm/bootstrap/values.yaml.tpl
+++ b/bootstrap/helm/bootstrap/values.yaml.tpl
@@ -55,6 +55,12 @@ externalDnsIdentityClientId: {{ importValue "Terraform" "externaldns_msi_client_
 
 pluralToken: {{ .Config.Token }}
 
+{{ if .Acme }}
+acme:
+  kid: {{ .Acme.KeyId }}
+  secret: {{ .Acme.Secret }}
+{{ end }}
+
 {{ if $pluraldns }}
 {{ $eab := eabCredential $providerArgs.cluster $providerArgs.provider }}
 acmeServer: https://acme.zerossl.com/v2/DV90


### PR DESCRIPTION
## Summary

Also take the opportuntity to give it a plural specific name.  I'll add a context option to make this globally enabled so we can start migrating apps to it.

## Test Plan
local link, verified issuer can be created/recreated


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x]  No images hosted from dockerhub
- [x]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [x]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [x]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [x]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [x]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP