### PR TITLE
Allow airflow to support new cert issuer

### DIFF
--- a/airflow/helm/airflow/Chart.yaml
+++ b/airflow/helm/airflow/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: airflow
 description: A Helm chart for airflow deployable on plural
 type: application
-version: 0.3.24
+version: 0.3.25
 appVersion: "1.16.0"
 sources:
   - https://github.com/pluralsh/plural-artifacts/airflow/helm/airflow

--- a/airflow/helm/airflow/values.yaml.tpl
+++ b/airflow/helm/airflow/values.yaml.tpl
@@ -97,11 +97,20 @@ airflow:
         # force users to re-auth after 30min of inactivity (to keep roles in sync)
         PERMANENT_SESSION_LIFETIME = 1800
   {{ end }}
+
   ingress:
     web:
       host: {{ $hostname }}
-      {{- if eq .Provider "kind" }}
+      {{ if and .Globals .Globals.CertIssuer }}
+      tls:
+        secretName: airflow-plural-tls
+      {{ end }}
       annotations:
+        plural.sh/dummy: 'true'
+      {{ if and .Globals .Globals.CertIssuer }}
+        cert-manager.io/cluster-issuer: {{ .Globals.CertIssuer }}
+      {{ end }}
+      {{- if eq .Provider "kind" }}
         external-dns.alpha.kubernetes.io/target: "127.0.0.1"
       {{- end }}
 


### PR DESCRIPTION
## Summary
We'll need to do this everywhere, but this approach gives us a few things:
* allows all new users to start using the plural issuer
* prevents a mass migration of existing clusters onto it, which could trigger rate limits/be generally risky

## Test Plan
local link


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP