### PR TITLE
Add correct uriFormats for gitlab

### DIFF
--- a/gitlab/plural/recipes/aws-gitlab.yaml
+++ b/gitlab/plural/recipes/aws-gitlab.yaml
@@ -3,7 +3,7 @@ description: Installs gitlab on an EKS cluster
 provider: AWS
 oidcSettings:
   authMethod: BASIC
-  uriFormat: https://gitlab.{subdomain}/users/auth/plural/callback
+  uriFormat: https://gitlab.{subdomain}/users/auth/openid_connect/callback
   subdomain: true
 dependencies:
 - repo: bootstrap

--- a/gitlab/plural/recipes/gcp-gitlab.yaml
+++ b/gitlab/plural/recipes/gcp-gitlab.yaml
@@ -3,7 +3,7 @@ description: Installs gitlab on a GKE cluster
 provider: GCP
 oidcSettings:
   authMethod: BASIC
-  uriFormat: https://gitlab.{subdomain}/users/auth/plural/callback
+  uriFormat: https://gitlab.{subdomain}/users/auth/openid_connect/callback
   subdomain: true
 dependencies:
 - repo: bootstrap

--- a/gitlab/repository.yaml
+++ b/gitlab/repository.yaml
@@ -6,7 +6,7 @@ notes: plural/notes.tpl
 gitUrl: https://gitlab.com/gitlab-org/gitlab
 homepage: https://about.gitlab.com/
 oauthSettings:
-  uriFormat: https://{domain}/users/auth/plural/callback
+  uriFormat: https://{domain}/users/auth/openid_connect/callback
   authMethod: BASIC
 tags:
 - tag: ci


### PR DESCRIPTION
## Summary

a user who recently tried to set up gitlab realized these were incorrect, this should fix

## Test Plan
verified locally


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP