### PR TITLE
AWS k8s 1.22 part 2

### DIFF
--- a/bootstrap/terraform/aws-bootstrap/deps.yaml
+++ b/bootstrap/terraform/aws-bootstrap/deps.yaml
@@ -2,8 +2,9 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: Creates an EKS cluster and prepares it for bootstrapping
-  version: 0.1.46
+  version: 0.1.47
 spec:
+  breaking: true
   dependencies: []
   providers:
   - aws

--- a/bootstrap/terraform/aws-bootstrap/main.tf
+++ b/bootstrap/terraform/aws-bootstrap/main.tf
@@ -88,7 +88,7 @@ module "multi_az_node_groups" {
 resource "aws_eks_addon" "vpc_cni" {
   cluster_name = module.cluster.cluster_id
   addon_name   = "vpc-cni"
-  addon_version     = "v1.11.3-eksbuild.1"
+  addon_version     = var.vpc_cni_addon_version
   resolve_conflicts = "OVERWRITE"
   tags = {
       "eks_addon" = "vpc-cni"
@@ -102,7 +102,7 @@ resource "aws_eks_addon" "vpc_cni" {
 resource "aws_eks_addon" "core_dns" {
   cluster_name      = module.cluster.cluster_id
   addon_name        = "coredns"
-  addon_version     = "v1.8.4-eksbuild.1"
+  addon_version     = var.core_dns_addon_version
   resolve_conflicts = "OVERWRITE"
   tags = {
       "eks_addon" = "coredns"
@@ -116,7 +116,7 @@ resource "aws_eks_addon" "core_dns" {
 resource "aws_eks_addon" "kube_proxy" {
   cluster_name      = module.cluster.cluster_id
   addon_name        = "kube-proxy"
-  addon_version     = "v1.21.14-eksbuild.2"
+  addon_version     = var.kube_proxy_addon_version
   resolve_conflicts = "OVERWRITE"
   tags = {
       "eks_addon" = "kube-proxy"

--- a/bootstrap/terraform/aws-bootstrap/variables.tf
+++ b/bootstrap/terraform/aws-bootstrap/variables.tf
@@ -13,6 +13,24 @@ variable "kubernetes_version" {
   default = "1.22"
 }
 
+variable "vpc_cni_addon_version" {
+  type = string
+  default = "v1.12.0-eksbuild.2"
+  description = "The version of the VPC-CNI addon to use"
+}
+
+variable "core_dns_addon_version" {
+  type = string
+  default = "v1.8.7-eksbuild.1"
+  description = "The version of the CoreDNS addon to use"
+}
+
+variable "kube_proxy_addon_version" {
+  type = string
+  default = "v1.22.16-eksbuild.3"
+  description = "The version of the kube-proxy addon to use"
+}
+
 variable "cluster_name" {
   type = string
   default = "plural"
@@ -123,7 +141,7 @@ variable "node_groups_defaults" {
 
     instance_types = ["t3.large", "t3a.large"]
     disk_size = 50
-    ami_release_version = "1.21.14-20220824"
+    ami_release_version = "1.22.15-20221222"
     force_update_version = true
     ami_type = "AL2_x86_64"
     k8s_labels = {}


### PR DESCRIPTION
## Summary
This PR upgrades the node group AMI version for the EKS node groups, along with the managed add-on versions. This is a breaking change since it can't be deployed by the console as the nodes will need to be rolled.


## Test Plan
Local linking.