### PR TITLE
chore(ray): update aws node groups to k8s 1.22

### DIFF
--- a/ray/terraform/aws/deps.yaml
+++ b/ray/terraform/aws/deps.yaml
@@ -1,13 +1,13 @@
 apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
-  description: ray aws setup 
-  version: 0.1.1
+  description: ray aws setup
+  version: 0.1.2
 spec:
   dependencies:
   - name: aws-bootstrap
     repo: bootstrap
     type: terraform
-    version: '>= 0.1.2'
+    version: '>= 0.1.47'
   providers:
   - aws

--- a/ray/terraform/aws/main.tf
+++ b/ray/terraform/aws/main.tf
@@ -11,7 +11,7 @@ resource "kubernetes_namespace" "ray" {
 
 module "single_az_node_groups" {
   count                  = "${var.create_single_az_node_groups ? 1 : 0}"
-  source                 = "github.com/pluralsh/module-library//terraform/eks-node-groups/single-az-node-groups?ref=df068595c3e91590d11e1ace11e1d688630f03d6"
+  source                 = "github.com/pluralsh/module-library//terraform/eks-node-groups/single-az-node-groups?ref=20e64863ffc5e361045db8e6b81b9d244a55809e"
   cluster_name           = var.cluster_name
   default_iam_role_arn   = var.node_role_arn
   tags                   = var.tags

--- a/ray/terraform/aws/variables.tf
+++ b/ray/terraform/aws/variables.tf
@@ -32,7 +32,7 @@ variable "node_groups_defaults" {
 
     instance_types = ["t3.large", "t3a.large"]
     disk_size = 50
-    ami_release_version = "1.21.14-20220824"
+    ami_release_version = "1.22.15-20221222"
     force_update_version = true
     ami_type = "AL2_x86_64"
     k8s_labels = {}


### PR DESCRIPTION
## Summary
This PR updates the aws node groups you can deploy alongside Ray to K8s 1.22, which we recently updated to.


## Test Plan
Local linking.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP