### PR TITLE
Add ability to toggle between regional/zonal gke clusters

### DIFF
--- a/bootstrap/terraform/gcp-bootstrap/deps.yaml
+++ b/bootstrap/terraform/gcp-bootstrap/deps.yaml
@@ -2,7 +2,7 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: Creates a GKE cluster and adds initial configuration
-  version: 0.2.13
+  version: 0.2.14
 spec:
   dependencies: []
   providers:

--- a/bootstrap/terraform/gcp-bootstrap/main.tf
+++ b/bootstrap/terraform/gcp-bootstrap/main.tf
@@ -61,6 +61,8 @@ module "gke" {
   kubernetes_version         = var.kubernetes_version
   filestore_csi_driver       = true
   release_channel            = var.release_channel
+  regional                   = var.regional_cluster
+  zones                      = var.cluster_zones
 
   node_pools = var.node_pools
 

--- a/bootstrap/terraform/gcp-bootstrap/variables.tf
+++ b/bootstrap/terraform/gcp-bootstrap/variables.tf
@@ -324,3 +324,16 @@ variable "release_channel" {
   description = "The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`."
   default     = null
 }
+
+variable "regional_cluster" {
+  type        = bool
+  description = "Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!)"
+  default     = true
+}
+
+
+variable "cluster_zones" {
+  type        = list(string)
+  description = "The zones to host the cluster in (optional if regional cluster / required if zonal)"
+  default     = []
+}


### PR DESCRIPTION
## Summary

Exposing this toggle, with clear language that it will force control plane recreation.

## Test Plan
plural link


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP