### PR TITLE
Add app docs for airflow, airbyte, superset

### DIFF
--- a/.github/workflows/matrix-vendor-and-publish.yml
+++ b/.github/workflows/matrix-vendor-and-publish.yml
@@ -215,7 +215,7 @@ jobs:
       uses: pluralsh/setup-plural@v0.1.5
       with: 
         config: ${{ secrets.PLURAL_CONF }}
-        vsn: 0.5.18
+        vsn: 0.6.1
     - run: plural apply -f ${{ matrix.pluralfile }}
     - uses: 8398a7/action-slack@v3
       with:

--- a/airbyte/plural/docs/basic-auth.md
+++ b/airbyte/plural/docs/basic-auth.md
@@ -1,0 +1,30 @@
+## Configuring Basic Auth
+
+Airbyte's api and web interface is not authenticated by default.  We provide an oauth proxy by default to grant some security to your airbyte install, but in order to integrate with tools like airflow, you'll likely want a means to authenticate with static creds.  That's where basic auth can be very useful.  The process is very simple.
+
+### modify context.yaml
+
+in the `context.yaml` file at the root of your repo, simply add:
+
+```yaml
+configuration:
+  airbyte:
+    users:
+      <name>: <password>
+      <name2>: <password2>
+```
+you can use `plural crypto random` to generate a high-entropy password if that is helpful as well.
+
+### redeploy
+
+Simply run `plural build && plural deploy --commit "enabling basic auth"` to wire in the credentials to our oauth proxy.  Occasionally you need to restart the web pods to get it to take, you can find them with:
+
+```sh
+kubectl get pods -n airbyte | grep airbyte-web
+```
+
+then delete them (allowing k8s to restart) with:
+
+```sh
+kubectl delete pod <name> -n airbyte
+```

--- a/airbyte/plural/docs/bring-your-own-db.md
+++ b/airbyte/plural/docs/bring-your-own-db.md
@@ -1,0 +1,44 @@
+## Connecting to a managed SQL instance
+
+We ship airbyte with the zalando postgres operator's db for persistence by default.  This provides a lot of the benefits of a managed postgres instance at a lower cost, but if you'd rather use a familiar service like RDS this is still possible.  You'll need to do a few things:
+
+### edit context.yaml
+
+At the root of the repo, edit the `context.yaml` field and set `configuration.airbyte.postgresDisabled: true`, this will allow us to reconfigure airbyte for bring-your-own-db.
+
+### save the database password to a secret
+
+you can use a number of methods for this, but simply adding a secret file as `airbyte/helm/airbyte/templates/db-password.yaml` like:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: airbyte-db-password
+stringData:
+  password: {{ .Values.externalDb.password }}
+```
+
+Note: this password needs to be in the `airbyte` namespace.  If you put it in our wrapper helm chart, that will be done by default for you.
+
+### modify airbyte's helm values.yaml 
+
+If you go to `airbyte/helm/airbyte/values.yaml` you'll need to provide credentials for postgres.  They should look something like:
+
+```yaml
+externalDb:
+  password: <my password>
+airbyte:
+  airbyte:
+    externalDatabase:
+      database: <YOUR_DB_NAME>
+      host: <YOUR_DB_URL>
+      existingSecret: airbyte-db-password
+      existingSecretPasswordKey: password
+      user: <YOU_DB_USER>
+      port: 5432
+```
+
+### redeploy
+
+From there, you should be able to run `plural build && plural deploy --commit "using existing postgres instance"` to use the managed sql instance

--- a/airbyte/repository.yaml
+++ b/airbyte/repository.yaml
@@ -3,6 +3,7 @@ description: An open-source data integration engine for modern data teams.
 category: DATA
 icon: plural/icons/airbyte.png
 notes: plural/notes.tpl
+docs: plural/docs
 gitUrl: https://github.com/airbytehq/airbyte
 homepage: https://www.airbyte.com
 oauthSettings:

--- a/airflow/plural/docs/bring-your-db.md
+++ b/airflow/plural/docs/bring-your-db.md
@@ -1,0 +1,47 @@
+## Connecting to a managed SQL instance
+
+We ship airbyte with the zalando postgres operator's db for persistence by default.  This provides a lot of the benefits of a managed postgres instance at a lower cost, but if you'd rather use a familiar service like RDS this is still possible.  You'll need to do a few things:
+
+### edit context.yaml
+
+At the root of the repo, edit the `context.yaml` field and set `configuration.airflow.postgresDisabled: true`, this will allow us to reconfigure airflow for bring-your-own-db.
+
+### save the database password to a secret
+
+you can use a number of methods for this, but simply adding a secret file as `airflow/helm/airflow/templates/db-password.yaml` like:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: airflow-db-password
+stringData:
+  password: {{ .Values.externalDb.password }}
+```
+
+Note: this password needs to be in the `airflow` namespace.  If you put it in our wrapper helm chart, that will be done by default for you.
+
+### modify airflow's helm values.yaml 
+
+If you go to `airflow/helm/airflow/values.yaml` you'll need to provide credentials for postgres.  They should look something like:
+
+```yaml
+externalDb:
+  password: <my password>
+airflow:
+  airflow:
+    externalDatabase:
+      database: <YOUR_DB_NAME>
+      host: <YOUR_DB_URL>
+      passwordSecret: airflow-db-password
+      passwordSecretKey: password
+      user: <YOU_DB_USER>
+      port: 5432
+
+      # use this for any extra connection-string settings, e.g. ?sslmode=disable
+      properties: "?sslmode=allow"
+```
+
+### redeploy
+
+From there, you should be able to run `plural build && plural deploy --commit "using existing postgres instance"` to use the managed sql instance

--- a/airflow/plural/docs/pip-packages.md
+++ b/airflow/plural/docs/pip-packages.md
@@ -1,0 +1,26 @@
+## Installing pip packages
+
+Frequently an airflow project needs more than our default pip setup installed to work fully.  Airflow's codebase is brittle, and we recommend you handle pip installs by baking a new docker image against ours and then wiring it into your installation.  It's not actually too hard, and we can walk you through it.
+
+### Custom Dockerfile
+
+The dockerfile for our image is found at https://github.com/pluralsh/plural-artifacts/blob/main/airflow/Dockerfile.  You'll also want to keep the `requirements.txt` file adjacent to it.  Simply move these two wherever you manage docker, add whatever pip packages to `requirements.txt` and push it to your container registry.
+
+### wire airflow to point to new dockerfile
+
+You'll then want to edit `airflow/helm/airflow/values.yaml` in your installation repo with something like:
+
+```yaml
+airflow:
+  airflow:
+    airflow:
+      image:
+        repository: your.docker.repository
+        tag: your-tag
+```
+
+Alternatively, you should be able to do this in the configuration section for airflow in your plural console as well.
+
+### redeploy
+
+from there you can simply run `plural build && plural deploy --commit "using custom docker image"` to set this up

--- a/airflow/repository.yaml
+++ b/airflow/repository.yaml
@@ -3,6 +3,7 @@ description: Open-source workflow management system that allows data engineers t
 category: DATA
 icon: plural/icons/airflow.png
 notes: plural/notes.tpl
+docs: plural/docs
 gitUrl: https://github.com/apache/airflow
 homepage: https://airflow.apache.org/
 oauthSettings:

--- a/superset/plural/docs/pip-packages.md
+++ b/superset/plural/docs/pip-packages.md
@@ -1,0 +1,26 @@
+## Adding additional pip packages
+
+Superset doesn't come pre-installed with all drivers you might need for your visualizations.  To add additional db drivers, the most stable solution is to extend our docker image, which is relatively easy to do.
+
+### Build your extended image
+
+First copy the dockerfile here https://github.com/pluralsh/plural-artifacts/blob/main/superset/Dockerfile to wherever you want to manage your image.  You'll also want to copy the requirements.txt in the same subfolder, and add whatever additional packages you want to it.  Build the image then push it to your registry of choice to use it in the next step.
+
+### Wire Superset with this image
+
+
+You'll then want to edit `superset/helm/superset/values.yaml` in your installation repo with something like:
+
+```yaml
+superset:
+  superset:
+    image:
+      repository: your.docker.repository
+      tag: your-tag
+```
+
+Alternatively, you should be able to do this in the configuration section for superset in your plural console as well.
+
+### redeploy
+
+from there you can simply run `plural build && plural deploy --commit "using custom docker image"` to set this up

--- a/superset/repository.yaml
+++ b/superset/repository.yaml
@@ -3,6 +3,7 @@ description: An open-source modern data exploration and visualization platform.
 category: DATA
 icon: plural/icons/superset.png
 notes: plural/notes.tpl
+docs: plural/docs
 homepage: https://superset.apache.org/
 gitUrl: https://github.com/apache/superset
 oauthSettings:


### PR DESCRIPTION
## Summary

These are the docs I remember having the most customization requests.  We can probably add more but this is a great starting point.

## Test Plan
n/a


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP