### PR TITLE
Improve postgres liveness probes

### DIFF
--- a/postgres/helm/postgres/Chart.yaml
+++ b/postgres/helm/postgres/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: postgres
 description: A Helm chart for deploying the zalando postgres operator
 type: application
-version: 0.2.11
+version: 0.2.12
 appVersion: "1.8.2"

--- a/postgres/helm/postgres/values.yaml
+++ b/postgres/helm/postgres/values.yaml
@@ -177,13 +177,13 @@ configKubernetes:
   watched_namespace: "*"  # listen to all namespaces
 
   liveness_probe:
-    failureThreshold: 3
+    failureThreshold: 6
     httpGet:
       path: /readiness
       port: 8008
       scheme: HTTP
-    initialDelaySeconds: 10
-    periodSeconds: 10
+    initialDelaySeconds: 15
+    periodSeconds: 60
     successThreshold: 1
     timeoutSeconds: 5
 


### PR DESCRIPTION
## Summary
Large databases cannot be cloned in time w/ current probes.  This gives a bit more headroom at least.

## Test Plan
validated in prod cluster


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP