### PR TITLE
feat(postgres): enable AES256 bucket encryption on AWS

### DIFF
--- a/postgres/terraform/aws/deps.yaml
+++ b/postgres/terraform/aws/deps.yaml
@@ -2,7 +2,7 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: postgres aws setup
-  version: 0.1.1
+  version: 0.1.2
 spec:
   dependencies:
   - name: aws-bootstrap

--- a/postgres/terraform/aws/main.tf
+++ b/postgres/terraform/aws/main.tf
@@ -33,9 +33,17 @@ resource "aws_iam_policy" "postgres" {
 }
 
 resource "aws_s3_bucket" "wal" {
-  bucket = var.wal_bucket
-  acl    = "private"
-  force_destroy = true
+  bucket        = var.wal_bucket
+  acl           = "private"
+  force_destroy = var.force_destroy_bucket
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm     = "AES256"
+      }
+    }
+  }
 }
 
 data "aws_iam_policy_document" "postgres" {

--- a/postgres/terraform/aws/variables.tf
+++ b/postgres/terraform/aws/variables.tf
@@ -21,3 +21,9 @@ variable "role_name" {
   type = string
   default = "postgres"
 }
+
+variable "force_destroy_bucket" {
+  type        = bool
+  default     = false
+  description = "If true, the bucket will be deleted even if it contains objects."
+}

--- a/postgres/terraform/aws/variables.tf
+++ b/postgres/terraform/aws/variables.tf
@@ -24,6 +24,6 @@ variable "role_name" {
 
 variable "force_destroy_bucket" {
   type        = bool
-  default     = false
+  default     = true
   description = "If true, the bucket will be deleted even if it contains objects."
 }


### PR DESCRIPTION
## Summary
This PR enables AES256 encryption of the S3 bucket used for base backups and wal archives of postgres clusters managed by the operator.


## Test Plan
Deployed using local linking and checked that current base backups and wal archives are still appearing in the S3 bucket as expected.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP