### PR TITLE
Make cert-manager disable-able

### DIFF
--- a/bootstrap/helm/bootstrap/Chart.yaml
+++ b/bootstrap/helm/bootstrap/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   email: mguarino46@gmail.com
 - name: David van der Spek
   email: david@plural.sh
-version: 0.8.62
+version: 0.8.63
 dependencies:
 - name: external-dns
   version: 4.11.0
@@ -22,6 +22,7 @@ dependencies:
 - name: cert-manager
   version: v1.8.2
   repository: https://charts.jetstack.io
+  condition: cert-manager.enabled
 - name: cluster-autoscaler
   version: 9.21.0
   condition: cluster-autoscaler.enabled

--- a/bootstrap/helm/bootstrap/templates/issuer.yaml
+++ b/bootstrap/helm/bootstrap/templates/issuer.yaml
@@ -1,3 +1,4 @@
+{{ if index $.Values "cert-manager" "enabled" }}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -44,3 +45,4 @@ spec:
     - http01:
         ingress:
           class: nginx
+{{ end }}

--- a/bootstrap/helm/bootstrap/values.yaml
+++ b/bootstrap/helm/bootstrap/values.yaml
@@ -137,6 +137,7 @@ tigera-operator:
   enabled: false
 
 cert-manager:
+  enabled: true
   image:
     repository: dkr.plural.sh/bootstrap/jetstack/cert-manager-controller
     tag: v1.8.2


### PR DESCRIPTION
## Summary
Will help with some byok clusters too


## Test Plan
link

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP