### PR TITLE
Add oidc notes for airbyte + dagster

### DIFF
--- a/airbyte/plural/notes.tpl
+++ b/airbyte/plural/notes.tpl
@@ -3,4 +3,16 @@
 {{ if .OIDC }}
 It looks like you've enabled OIDC!  Login will be managed by plural from now on,
 feel free to add your teammembers in the OIDC configuration page in the plural UI.
+{{ else }}
+You did not enable OIDC for your airbyte install.  It will not be accessible publicly since airbyte OSS 
+does not have native authentication support.  If you want, you can enable oidc be running the bundle install command,
+eg:
+
+```
+plural bundle install airbyte airbyte-aws
+plural build --only airbyte
+plural deploy --commit "enable airbyte oidc"
+```
+
+(be sure to enable oidc at the end)
 {{ end }}

--- a/dagster/plural/notes.tpl
+++ b/dagster/plural/notes.tpl
@@ -1,1 +1,15 @@
-You can access your dagster implementation at {{ .Values.hostname }}
+You can access your dagster instance at {{ .Values.hostname }}
+
+{{ if not .OIDC }}
+You did not enable OIDC for your dagster install.  It will not be accessible publicly since dagster OSS 
+does not have native authentication support.  If you want, you can enable oidc be running the bundle install command,
+eg:
+
+```
+plural bundle install dagster dagster-aws
+plural build --only dagster
+plural deploy --commit "enable dagster oidc"
+```
+
+(be sure to enable oidc at the end)
+{{ end }}


### PR DESCRIPTION
## Summary

This will tell non-oidc users why they can't access the web ui

## Test Plan
n/a


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP