### PR TITLE
fix multi-az node groups

### DIFF
--- a/bootstrap/terraform/aws-bootstrap/deps.yaml
+++ b/bootstrap/terraform/aws-bootstrap/deps.yaml
@@ -2,9 +2,8 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: Creates an EKS cluster and prepares it for bootstrapping 
-  version: 0.1.47
+  version: 0.1.48
 spec:
-  breaking: true
   dependencies: []
   providers:
   - aws

--- a/bootstrap/terraform/aws-bootstrap/main.tf
+++ b/bootstrap/terraform/aws-bootstrap/main.tf
@@ -78,7 +78,7 @@ module "multi_az_node_groups" {
   tags                   = {}
   node_groups_defaults   = var.node_groups_defaults
 
-  node_groups            = var.create_cluster ? var.multi_az_node_groups : {}
+  node_groups            =  try(var.create_cluster ? var.multi_az_node_groups : tomap(false), {})
   set_desired_size       = false
   private_subnet_ids     = local.worker_private_subnet_ids
 


### PR DESCRIPTION
## Summary
After the BYOK PR, adding custom multi-az node groups is broken. This PR should fix it.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP