### PR TITLE
Bump superset pool size

### DIFF
--- a/superset/helm/superset/Chart.yaml
+++ b/superset/helm/superset/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: superset
 description: A Helm chart for superset on plural
 type: application
-version: 0.2.6
+version: 0.2.7
 appVersion: "1.5.0"
 dependencies:
 - name: superset

--- a/superset/helm/superset/values.yaml
+++ b/superset/helm/superset/values.yaml
@@ -118,7 +118,13 @@ superset:
       registry: gcr.io/pluralsh
       tag: 6.0.9-debian-10-r0
 
-  # configOverrides:
+  configOverrides:
+    pool_settings: |
+      SQLALCHEMY_POOL_SIZE = 25
+
+      SQLALCHEMY_MAX_OVERFLOW = 25
+
+      SQLALCHEMY_POOL_TIMEOUT = 180
   #   statsd_conf: |
   #     from superset.stats_logger import StatsdStatsLogger
   


### PR DESCRIPTION
## Summary
The default superset uses is teeny (5), and we see it frequently getting saturated.  This might help.

## Test Plan
local link


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP