### PR TITLE
Stabilize n8n encryption key

### DIFF
--- a/n8n/helm/n8n/Chart.yaml
+++ b/n8n/helm/n8n/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: n8n
 description: helm chart for n8n
 type: application
-version: 0.1.7
+version: 0.1.8
 appVersion: "0.213.0"
 dependencies:
 - name: postgres

--- a/n8n/helm/n8n/templates/deployment.yaml
+++ b/n8n/helm/n8n/templates/deployment.yaml
@@ -70,6 +70,11 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.database.secret }}
                   key: password
+            - name: N8N_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: n8n-encryption
+                  key: N8N_ENCRYPTION_KEY
           livenessProbe:
             httpGet:
               path: /

--- a/n8n/helm/n8n/templates/secret.yaml
+++ b/n8n/helm/n8n/templates/secret.yaml
@@ -4,11 +4,20 @@ kind: Secret
 metadata:
   name: n8n-smtp
   labels:
-{{ include "n8n.labels" . | indent 4 }}
+{{ include "n8n.labels" . | nindent 4 }}
 stringData:
   N8N_SMTP_HOST: {{ .Values.smtp.host | quote }}
   N8N_SMTP_USER: {{ .Values.smtp.user | quote }}
   N8N_SMTP_PASS: {{ .Values.smtp.password | quote }}
   N8N_SMTP_PORT: {{ .Values.smtp.port | quote }}
   N8N_SMTP_SENDER: {{ .Values.smtp.sender | quote }}
+---
 {{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: n8n-encryption
+  labels:
+{{ include "n8n.labels" . | nindent 4 }}
+stringData:
+  N8N_ENCRYPTION_KEY: {{ .Values.encryptionSecret | quote }}

--- a/n8n/helm/n8n/values.yaml
+++ b/n8n/helm/n8n/values.yaml
@@ -12,6 +12,8 @@ image:
 
 webhookUrl: https://example.com
 
+encryptionSecret: CHANGEME
+
 smtp:
 
 imagePullSecrets: []

--- a/n8n/helm/n8n/values.yaml.tpl
+++ b/n8n/helm/n8n/values.yaml.tpl
@@ -6,6 +6,8 @@ global:
 
 webhookUrl: https://{{ .Values.hostname }}
 
+encryptionSecret: {{ dedupe . "n8n.encryptionSecret" (randAlphaNum 24) }}
+
 {{ if .SMTP }}
 smtp:
   host: {{ .SMTP.Server }}


### PR DESCRIPTION
## Summary
Apparently this is regen'ed on boot, so passing it explicitly is a must

## Test Plan
local link

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP