### PR TITLE
Bump datahub frontend limit

### DIFF
--- a/datahub/helm/datahub/Chart.yaml
+++ b/datahub/helm/datahub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datahub
 description: helm chart for datahub
 type: application
-version: 0.1.12
+version: 0.1.13
 appVersion: v0.9.0
 dependencies:
 - name: datahub

--- a/datahub/helm/datahub/values.yaml
+++ b/datahub/helm/datahub/values.yaml
@@ -44,7 +44,7 @@ datahub:
         cpu: 10m
         memory: 500Mi
       limits:
-        memory: 500Mi
+        memory: 1Gi
     extraVolumes:
     - name: basic-auth-password
       secret:


### PR DESCRIPTION
## Summary
This was set far too strictly and caused xendits frontend to crash frequently.  Giving it some more headroom for now.


## Test Plan
link


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP