### PR TITLE
fix(ray): allows for changing the instance type

### DIFF
--- a/ray/terraform/aws/deps.yaml
+++ b/ray/terraform/aws/deps.yaml
@@ -2,7 +2,7 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: ray aws setup
-  version: 0.1.2
+  version: 0.1.3
 spec:
   dependencies:
   - name: aws-bootstrap

--- a/ray/terraform/aws/main.tf
+++ b/ray/terraform/aws/main.tf
@@ -11,7 +11,7 @@ resource "kubernetes_namespace" "ray" {
 
 module "single_az_node_groups" {
   count                  = "${var.create_single_az_node_groups ? 1 : 0}"
-  source                 = "github.com/pluralsh/module-library//terraform/eks-node-groups/single-az-node-groups?ref=20e64863ffc5e361045db8e6b81b9d244a55809e"
+  source                 = "github.com/pluralsh/module-library//terraform/eks-node-groups/single-az-node-groups?ref=4554ffb2c881904efa644b5a77fdb6df359b9171"
   cluster_name           = var.cluster_name
   default_iam_role_arn   = var.node_role_arn
   tags                   = var.tags


### PR DESCRIPTION
## Summary
Allows for changing the instance type of ray node groups without running into problems. The new upstream commit has the `create_before_destroy` lifecycle policy set to false which would avoid issues with the node group already existing when it needs to be recreated like when changing the instance types.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP