### PR TITLE
Disable opentelemetry

### DIFF
--- a/monitoring/helm/monitoring/Chart.yaml
+++ b/monitoring/helm/monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monitoring
 description: A Helm chart for Kubernetes
 type: application
-version: 0.2.22
+version: 0.2.23
 appVersion: "0.1.0"
 dependencies:
 - name: kube-prometheus-stack
@@ -19,6 +19,7 @@ dependencies:
 - name: opentelemetry-operator
   version: 0.12.0
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
+  condition: opentelemetry-operator.enabled
 - name: vpa
   version: 0.4.2
   repository: https://charts.fairwinds.com/stable

--- a/monitoring/helm/monitoring/values.yaml
+++ b/monitoring/helm/monitoring/values.yaml
@@ -295,7 +295,7 @@ opentelemetry-operator:
       repository: dkr.plural.sh/monitoring/kubebuilder/kube-rbac-proxy
       tag: v0.8.0
   collector:
-    enabled: true
+    enabled: false
     image:
       repository: gcr.io/pluralsh/otel/opentelemetry-collector
       tag: 0.59.0

--- a/monitoring/helm/monitoring/values.yaml
+++ b/monitoring/helm/monitoring/values.yaml
@@ -281,6 +281,7 @@ kube-prometheus-stack:
       probeSelector: {}
 
 opentelemetry-operator:
+  enabled: false
   manager:
     image:
       repository: dkr.plural.sh/monitoring/open-telemetry/opentelemetry-operator/opentelemetry-operator


### PR DESCRIPTION
## Summary
It's not really being used meaningfully, and it's caused a few failed installs so disable it until there's a better solve

## Test Plan
link


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP