### PR TITLE
remove namespace alert label

### DIFF
--- a/monitoring/helm/monitoring/Chart.yaml
+++ b/monitoring/helm/monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monitoring
 description: A Helm chart for Kubernetes
 type: application
-version: 0.2.23
+version: 0.2.24
 appVersion: "0.1.0"
 dependencies:
 - name: kube-prometheus-stack

--- a/monitoring/helm/monitoring/values.yaml
+++ b/monitoring/helm/monitoring/values.yaml
@@ -140,8 +140,6 @@ kube-prometheus-stack:
     enabled: false
 
   defaultRules:
-    additionalRuleLabels:
-      namespace: monitoring
     rules:
       kubeProxy: false
 


### PR DESCRIPTION
## Summary
The extra label being added to alerts breaks the ability to use the namespace label to sort alerts coming from a particular namespace. This PR removes the added namespace label from alerts so it is possible to filter alerts coming from a particular namespace.

![image](https://user-images.githubusercontent.com/28541758/221022151-92eb3d7b-bf74-499b-af11-277b792f97f4.png)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP