### PR TITLE
bootstrap: update aws eks node groups to 1.23

### DIFF
--- a/bootstrap/terraform/aws-bootstrap/deps.yaml
+++ b/bootstrap/terraform/aws-bootstrap/deps.yaml
@@ -2,8 +2,9 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: Creates an EKS cluster and prepares it for bootstrapping 
-  version: 0.1.50
+  version: 0.1.51
 spec:
+  breaking: true
   dependencies: []
   providers:
   - aws

--- a/bootstrap/terraform/aws-bootstrap/variables.tf
+++ b/bootstrap/terraform/aws-bootstrap/variables.tf
@@ -225,7 +225,7 @@ variable "node_groups_defaults" {
 
     instance_types = ["t3.large", "t3a.large"]
     disk_size = 50
-    ami_release_version = "1.22.15-20221222"
+    ami_release_version = "1.23.16-20230217"
     force_update_version = true
     ami_type = "AL2_x86_64"
     k8s_labels = {}


### PR DESCRIPTION
## Summary
This PR updates the EKS node groups to the latest AMI image for K8s 1.23.


## Test Plan
Local linking.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP