### PR TITLE
fix(ci): allow for vendoring images from aws ecr

### DIFF
--- a/.github/workflows/matrix-vendor-and-publish.yml
+++ b/.github/workflows/matrix-vendor-and-publish.yml
@@ -137,7 +137,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v1
       with:
         role-to-assume: arn:aws:iam::312272277431:role/github-actions/plural-artifacts-ecr
-        aws-region: us-east-2
+        aws-region: us-east-1
         role-session-name: PluralArtifacts
     - name: Login to Amazon ECR Public
       id: login-ecr-public

--- a/.github/workflows/matrix-vendor-cron.yml
+++ b/.github/workflows/matrix-vendor-cron.yml
@@ -89,7 +89,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v1
       with:
         role-to-assume: arn:aws:iam::312272277431:role/github-actions/plural-artifacts-ecr
-        aws-region: us-east-2
+        aws-region: us-east-1
         role-session-name: PluralArtifacts
     - name: Login to Amazon ECR Public
       id: login-ecr-public

--- a/.github/workflows/vendor-app.yml
+++ b/.github/workflows/vendor-app.yml
@@ -28,7 +28,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v1
       with:
         role-to-assume: arn:aws:iam::312272277431:role/github-actions/plural-artifacts-ecr
-        aws-region: us-east-2
+        aws-region: us-east-1
         role-session-name: PluralArtifacts
     - name: Login to Amazon ECR Public
       id: login-ecr-public


### PR DESCRIPTION
## Summary
Logging in to ECR wasn't working since it is not available in `us-east-2`, changing the region to `us-east-1` fixes it. This PR fixes it so we can vendor images hosted on ECR.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP