### PR TITLE
Handle legacy airflow installs

### DIFF
--- a/airflow/helm/airflow/Chart.yaml
+++ b/airflow/helm/airflow/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: airflow
 description: A Helm chart for airflow deployable on plural
 type: application
-version: 0.3.31
+version: 0.3.32
 appVersion: "1.16.0"
 sources:
   - https://github.com/pluralsh/plural-artifacts/airflow/helm/airflow

--- a/airflow/helm/airflow/values.yaml.tpl
+++ b/airflow/helm/airflow/values.yaml.tpl
@@ -21,8 +21,10 @@ exporter:
     relayAddress: "datadog.datadog:8125"
 {{ end }}
 
+{{ $sshCredentials := (or (and .Values.private_key (ne .Values.private_key "")) .airflow.sshConfig.id_rsa) }}
+
 {{ if not .Values.gitSyncDisabled }}
-{{- if and .Values.private_key (ne .Values.private_key "") }}
+{{- if $sshCredentials }}
 sshConfig:
   enabled: true
   id_rsa: {{ ternary .Values.private_key (dedupe . "airflow.sshConfig.id_rsa" "") (hasKey .Values "private_key") | quote }}
@@ -175,9 +177,6 @@ airflow:
   {{ end }}
     annotations:
       eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Project }}:role/{{ .Cluster }}-airflow"
-
-  
-  {{ $sshCredentials := (or (and .Values.private_key (ne .Values.private_key "")) .airflow.sshConfig.id_rsa) }}
 
   dags:
     gitSync:


### PR DESCRIPTION
## Summary
older airflow setups (ours) didn't use context to add ssh creds it seems, this will fix

## Test Plan
local link

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP