### PR TITLE
fix datahub setup jobs

### DIFF
--- a/datahub/helm/datahub/Chart.yaml
+++ b/datahub/helm/datahub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datahub
 description: helm chart for datahub
 type: application
-version: 0.1.14
+version: 0.1.15
 appVersion: v0.10.0
 dependencies:
 - name: datahub

--- a/datahub/helm/datahub/values.yaml
+++ b/datahub/helm/datahub/values.yaml
@@ -145,7 +145,7 @@ datahub:
   kafkaSetupJob:
     enabled: true
     image:
-      repository: gcr.io/pluralsh/linkedin/datahub-kafka-setup
+      repository: dkr.plural.sh/datahub/linkedin/datahub-kafka-setup
       tag: v0.10.0
     resources:
       requests:
@@ -166,7 +166,7 @@ datahub:
         enabled: true
     graph_service_impl: "elasticsearch"
     elasticsearch:
-      host: "elasticsearch-es-http.elasticsearch.svc"
+      host: "elasticsearch-es-http.elasticsearch"
       port: "9200"
       useSSL: "false"
       skipcheck: "false"
@@ -179,11 +179,11 @@ datahub:
       verify-certs: "false"
     kafka:
       bootstrap:
-        server: "kafka-kafka-bootstrap.kafka.svc:9092"
+        server: "kafka-kafka-bootstrap.kafka:9092"
       zookeeper:
-        server: "kafka-zookeeper-client.kafka.svc:2181"
+        server: "kafka-zookeeper-client.kafka:2181"
       schemaregistry:
-        url: "http://kafka-schema-registry.kafka.svc:8081"
+        url: "http://kafka-schema-registry.kafka:8081"
     sql:
       datasource:
         hostForpostgresqlClient: "plural-postgres-datahub"


### PR DESCRIPTION
## Summary
Apparently the DNS resolution for the kafka setup job can have issues. This should fix it.


## Test Plan
Fresh deploy using local linking

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP