### PR TITLE
Metabase upgrade

### DIFF
--- a/metabase/helm/metabase/Chart.yaml
+++ b/metabase/helm/metabase/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: metabase
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.10
-appVersion: "0.45.1"
+version: 0.1.11
+appVersion: "0.45.3"
 dependencies:
 - name: postgres
   version: 0.1.10

--- a/metabase/helm/metabase/values.yaml
+++ b/metabase/helm/metabase/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: dkr.plural.sh/metabase/metabase/metabase
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: v0.45.1
+  tag: v0.45.3
 
 listen:
   host: "0.0.0.0"


### PR DESCRIPTION
## Summary
Upgrade Metabase artifact to use [latest release](https://github.com/metabase/metabase/releases/tag/v0.45.3).

## Test Plan
Tested locally on dev cluster.

<img width="1831" alt="Zrzut ekranu 2023-03-23 o 11 27 36" src="https://user-images.githubusercontent.com/2823399/227175956-e77478e9-9c23-4c69-9fa2-42fe1af2cda5.png">

<img width="663" alt="Zrzut ekranu 2023-03-23 o 11 28 10" src="https://user-images.githubusercontent.com/2823399/227175994-4e917f52-7c18-4913-a139-150fdfa30ef9.png">

## Checklist
- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP