### PR TITLE
Don't set known hosts by default for airflow

### DIFF
--- a/airflow/helm/airflow/Chart.yaml
+++ b/airflow/helm/airflow/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: airflow
 description: A Helm chart for airflow deployable on plural
 type: application
-version: 0.3.32
+version: 0.3.33
 appVersion: "1.16.0"
 sources:
   - https://github.com/pluralsh/plural-artifacts/airflow/helm/airflow

--- a/airflow/helm/airflow/values.yaml.tpl
+++ b/airflow/helm/airflow/values.yaml.tpl
@@ -189,12 +189,12 @@ airflow:
       {{- if $sshCredentials }}
       sshSecret: airflow-ssh-config
       sshSecretKey: id_rsa
-      sshKnownHosts: {{ knownHosts | quote }}
+      sshKnownHosts: ""
       {{- else if and .Values.gitAccessToken (ne .Values.gitAccessToken "") }}
       httpSecret: airflow-git-http-config
       httpSecretUsernameKey: username
       httpSecretPasswordKey: password
       {{- end }}
       {{ else }}
-      enabled: false  
+      enabled: false
       {{ end }}

--- a/sentry/terraform/gcp/deps.yaml
+++ b/sentry/terraform/gcp/deps.yaml
@@ -2,7 +2,7 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: sentry gcp setup 
-  version: 0.1.2
+  version: 0.1.3
 spec:
   dependencies:
   - name: gcp-bootstrap

--- a/sentry/terraform/gcp/main.tf
+++ b/sentry/terraform/gcp/main.tf
@@ -26,7 +26,7 @@ resource "kubernetes_service_account" "sentry" {
 
 resource "google_storage_bucket" "filestore_bucket" {
   name = var.filestore_bucket
-  project = var.gcp_project_id
+  project = var.project_id
   force_destroy = true
   location = var.bucket_location
   


### PR DESCRIPTION
## Summary

I think bad knownhosts files might actually be the cause of some airflow setup failures, and if people really want the assurance, they can always just reconfigure it in their `values.yaml` file

## Test Plan
local link


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP