### PR TITLE
feat(airbyte-gcp): add airbyte workload identity sa

### DIFF
--- a/airbyte/terraform/gcp/deps.yaml
+++ b/airbyte/terraform/gcp/deps.yaml
@@ -2,7 +2,7 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: airbyte gcp setup 
-  version: 0.1.3
+  version: 0.1.4
 spec:
   dependencies:
   - name: gcp-bootstrap

--- a/airbyte/terraform/gcp/variables.tf
+++ b/airbyte/terraform/gcp/variables.tf
@@ -33,3 +33,9 @@ variable "cluster_name" {
   type = string
   default = "plural"
 }
+
+variable "roles" {
+  type        = list(string)
+  description = "A list of roles to be added to the airbyte workload identity service account"
+  default     = []
+}


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you with us! -->

## Summary
- Added GCP SA bound to default K8S sa on airbyte namespace to be able to add specific roles

## Test Plan
- Added a BigQuery data editor and a BigQuery user to the roles of this new sa and tested a job sync on airbyte with BigQuery as destination

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [x]  GCP