### PR TITLE
Allow loki to have in-vpc ingress

### DIFF
--- a/loki/helm/loki/Chart.yaml
+++ b/loki/helm/loki/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: loki
 description: helm chart for loki
 type: application
-version: 0.1.10
+version: 0.1.11
 appVersion: "v2.6.1"
 dependencies:
 - name: loki-distributed

--- a/loki/helm/loki/values.yaml
+++ b/loki/helm/loki/values.yaml
@@ -65,9 +65,6 @@ loki-distributed:
         kubernetes.io/tls-acme: "true"
         cert-manager.io/cluster-issuer: letsencrypt-prod
         nginx.ingress.kubernetes.io/force-ssl-redirect: 'true'
-        nginx.ingress.kubernetes.io/auth-type: basic
-        nginx.ingress.kubernetes.io/auth-secret: basic-auth
-        nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - foo'
   compactor:
     enabled: true
     extraArgs:

--- a/loki/helm/loki/values.yaml.tpl
+++ b/loki/helm/loki/values.yaml.tpl
@@ -29,6 +29,24 @@ loki-distributed:
   gateway:
     ingress:
       enabled: true
+      annotations:
+        nginx.ingress.kubernetes.io/auth-type: basic
+        nginx.ingress.kubernetes.io/auth-secret: basic-auth
+        nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - foo'
+      hosts:
+      - host: {{ .Values.hostname | quote }}
+        paths:
+          - path: /
+            pathType: Prefix
+      tls:
+      - hosts:
+        - {{ .Values.hostname | quote }}
+        secretName: loki-tls
+  {{ else if .Values.hostname }}
+  gateway:
+    ingress:
+      enabled: true
+      ingressClassName: internal-nginx
       hosts:
       - host: {{ .Values.hostname | quote }}
         paths:

--- a/loki/plural/recipes/loki-aws.yaml
+++ b/loki/plural/recipes/loki-aws.yaml
@@ -14,6 +14,11 @@ sections:
     type: BUCKET
     default: loki
     documentation: bucket to store the logs in
+  - name: hostname
+    type: domain
+    default: loki
+    documentation: the hostname you'll deploy loki with (will only be available on a private network)
+    optional: true
   items:
   - type: TERRAFORM
     name: aws

--- a/loki/plural/recipes/loki-azure.yaml
+++ b/loki/plural/recipes/loki-azure.yaml
@@ -14,6 +14,11 @@ sections:
     type: BUCKET
     default: loki
     documentation: storage container to store the logs in
+  - name: hostname
+    type: domain
+    default: loki
+    documentation: the hostname you'll deploy loki with (will only be available on a private network)
+    optional: true
   items:
   - type: TERRAFORM
     name: azure

--- a/loki/plural/recipes/loki-gcp.yaml
+++ b/loki/plural/recipes/loki-gcp.yaml
@@ -14,6 +14,11 @@ sections:
     type: BUCKET
     default: loki
     documentation: bucket to store the logs in
+  - name: hostname
+    type: domain
+    default: loki
+    documentation: the hostname you'll deploy loki with (will only be available on a private network)
+    optional: true
   items:
   - type: TERRAFORM
     name: gcp


### PR DESCRIPTION
## Summary
Allows for another auth mode for loki ingress


## Test Plan
link


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP