### PR TITLE
fix: allow for pushing trace shield chart

### DIFF
--- a/trace-shield/helm/trace-shield/values.yaml.tpl
+++ b/trace-shield/helm/trace-shield/values.yaml.tpl
@@ -34,7 +34,9 @@ kratos:
   kratos:
     config:
       cookies:
+        {{- if .Values.frontendHostname }}
         domain: {{ regexReplaceAll "^.+?\\." .Values.frontendHostname "" }}
+        {{- end }}
       serve:
         public:
           base_url: https://{{ .Values.frontendHostname }}/.ory/kratos/public/


### PR DESCRIPTION
## Summary
Couldn't push the previous chart because we don't adequately mock values when performing linting before pushing a chart. This change works around that issue.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP