### PR TITLE
fix: use the correct yaml key for release status

### DIFF
--- a/.github/workflows/matrix-vendor-and-publish.yml
+++ b/.github/workflows/matrix-vendor-and-publish.yml
@@ -226,7 +226,7 @@ jobs:
       uses: pluralsh/setup-plural@v0.1.5
       with: 
         config: ${{ secrets.PLURAL_CONF }}
-        vsn: 0.6.16
+        vsn: 0.6.17
     - run: plural apply -f ${{ matrix.pluralfile }}
     - uses: 8398a7/action-slack@v3
       with:

--- a/grafana-agent/repository.yaml
+++ b/grafana-agent/repository.yaml
@@ -1,7 +1,7 @@
 name: grafana-agent
 description: grafana-agent deployed on plural
 category: DEVOPS
-releaseStatus: ALPHA
+release_status: ALPHA
 icon: plural/icons/grafana-agent.png
 notes: plural/notes.tpl
 homepage: https://grafana.com/oss/agent/

--- a/loki/helm/loki/values.yaml.tpl
+++ b/loki/helm/loki/values.yaml.tpl
@@ -1,4 +1,4 @@
-{{ $traceShield := (index .Configuration "trace-shield") }}
+{{ $traceShield := (dig "Configuration" "grafana-agent" .) }}
 {{ $redisNamespace := namespace "redis" }}
 {{ $redisValues := .Applications.HelmValues "redis" }}
 {{ $monitoringNamespace := namespace "monitoring" }}
@@ -16,7 +16,7 @@ basicAuth:
   password: {{ .Values.basicAuth.password }}
 {{- end }}
 
-{{- if (index .Configuration "grafana-agent") }}
+{{- if $traceShield }}
 promtail:
   enabled: false
 {{- end }}

--- a/mimir/helm/mimir/values.yaml.tpl
+++ b/mimir/helm/mimir/values.yaml.tpl
@@ -1,4 +1,4 @@
-{{ $traceShield := (index .Configuration "trace-shield") }}
+{{ $traceShield := (dig "Configuration" "trace-shield" .) }}
 
 {{- if eq .Provider "azure" }}
 global:

--- a/mimir/repository.yaml
+++ b/mimir/repository.yaml
@@ -1,7 +1,7 @@
 name: mimir
 description: mimir deployed on plural
 category: DEVOPS
-releaseStatus: ALPHA
+release_status: ALPHA
 icon: plural/icons/mimir.png
 notes: plural/notes.tpl
 homepage: https://grafana.com/oss/mimir/

--- a/monitoring/helm/monitoring/values.yaml.tpl
+++ b/monitoring/helm/monitoring/values.yaml.tpl
@@ -6,12 +6,12 @@ global:
 kube-prometheus-stack:
   grafana:
     namespaceOverride: {{ $monitoringNamespace }}
-{{- if index .Configuration "grafana-agent" }}
+{{- if dig "Configuration" "grafana-agent" . }}
   alertmanager:
     enabled: false
 {{- end }}
   prometheus:
-    {{- if index .Configuration "grafana-agent" }}
+    {{- if dig "Configuration" "grafana-agent" . }}
     enabled: false
     {{- end }}
     prometheusSpec:

--- a/trace-shield/helm/trace-shield/Chart.yaml
+++ b/trace-shield/helm/trace-shield/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: trace-shield
 description: helm chart for trace-shield
 type: application
-version: 0.1.1
-appVersion: "v0.1.0"
+version: 0.1.2
+appVersion: "v0.1.1"
 dependencies:
 - name: kratos
   version: 0.29.0

--- a/trace-shield/helm/trace-shield/values.yaml
+++ b/trace-shield/helm/trace-shield/values.yaml
@@ -2,10 +2,10 @@ backend:
   replicaCount: 1
 
   image:
-    repository: ghcr.io/pluralsh/oauth-playground/backend
+    repository: ghcr.io/pluralsh/trace-shield/backend
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: sha-dc7d00c
+    tag: 0.1.1
 
   imagePullSecrets: []
   nameOverride: ""
@@ -66,10 +66,10 @@ frontend:
   replicaCount: 1
 
   image:
-    repository: ghcr.io/pluralsh/oauth-playground/frontend
+    repository: ghcr.io/pluralsh/trace-shield/backend
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: sha-dc7d00c
+    tag: 0.1.1
 
   imagePullSecrets: []
   nameOverride: ""

--- a/trace-shield/helm/trace-shield/values.yaml
+++ b/trace-shield/helm/trace-shield/values.yaml
@@ -66,7 +66,7 @@ frontend:
   replicaCount: 1
 
   image:
-    repository: ghcr.io/pluralsh/trace-shield/backend
+    repository: ghcr.io/pluralsh/trace-shield/frontend
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
     tag: 0.1.1

--- a/trace-shield/repository.yaml
+++ b/trace-shield/repository.yaml
@@ -1,7 +1,7 @@
 name: trace-shield
 description: trace-shield deployed on plural
 category: DEVOPS
-releaseStatus: ALPHA
+release_status: ALPHA
 icon: plural/icons/trace-shield.png
 notes: plural/notes.tpl
 tags:


### PR DESCRIPTION
## Summary
The yaml key for the release status was incorrect. This PR fixes setting these applications as alpha.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP