### PR TITLE
fix: add grafana agent as dependency + fix some templates

### DIFF
--- a/loki/helm/loki/Chart.yaml
+++ b/loki/helm/loki/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: loki
 description: helm chart for loki
 type: application
-version: 0.1.14
+version: 0.1.15
 appVersion: "v2.6.1"
 dependencies:
 - name: loki-distributed

--- a/loki/helm/loki/values.yaml.tpl
+++ b/loki/helm/loki/values.yaml.tpl
@@ -16,7 +16,7 @@ basicAuth:
   password: {{ .Values.basicAuth.password }}
 {{- end }}
 
-{{- if $traceShield }}
+{{- if and .Configuration (index .Configuration "grafana-agent") }}
 promtail:
   enabled: false
 {{- end }}

--- a/loki/helm/loki/values.yaml.tpl
+++ b/loki/helm/loki/values.yaml.tpl
@@ -1,4 +1,5 @@
 {{ $traceShield := and .Configuration (index .Configuration "grafana-agent") }}
+{{ $grafanaAgent := and .Configuration (index .Configuration "grafana-agent") }}
 {{ $redisNamespace := namespace "redis" }}
 {{ $redisValues := .Applications.HelmValues "redis" }}
 {{ $monitoringNamespace := namespace "monitoring" }}
@@ -16,7 +17,7 @@ basicAuth:
   password: {{ .Values.basicAuth.password }}
 {{- end }}
 
-{{- if and .Configuration (index .Configuration "grafana-agent") }}
+{{- if $grafanaAgent }}
 promtail:
   enabled: false
 {{- end }}

--- a/loki/helm/loki/values.yaml.tpl
+++ b/loki/helm/loki/values.yaml.tpl
@@ -1,4 +1,4 @@
-{{ $traceShield := and .Configuration (index .Configuration "grafana-agent") }}
+{{ $traceShield := and .Configuration (index .Configuration "trace-shield") }}
 {{ $grafanaAgent := and .Configuration (index .Configuration "grafana-agent") }}
 {{ $redisNamespace := namespace "redis" }}
 {{ $redisValues := .Applications.HelmValues "redis" }}

--- a/mimir/helm/mimir/Chart.yaml
+++ b/mimir/helm/mimir/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mimir
 description: helm chart for mimir
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 2.7.1
 dependencies:
 - name: mimir-distributed

--- a/mimir/helm/mimir/values.yaml.tpl
+++ b/mimir/helm/mimir/values.yaml.tpl
@@ -1,4 +1,4 @@
-{{ $traceShield := (dig "Configuration" "trace-shield" .) }}
+{{ $traceShield := and .Configuration (index .Configuration "trace-shield" .) }}
 
 {{- if eq .Provider "azure" }}
 global:

--- a/mimir/helm/mimir/values.yaml.tpl
+++ b/mimir/helm/mimir/values.yaml.tpl
@@ -1,4 +1,4 @@
-{{ $traceShield := and .Configuration (index .Configuration "trace-shield" .) }}
+{{ $traceShield := and .Configuration (index .Configuration "trace-shield") }}
 
 {{- if eq .Provider "azure" }}
 global:

--- a/monitoring/helm/monitoring/Chart.yaml
+++ b/monitoring/helm/monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monitoring
 description: A Helm chart for Kubernetes
 type: application
-version: 0.2.25
+version: 0.2.26
 appVersion: "0.1.0"
 dependencies:
 - name: kube-prometheus-stack

--- a/monitoring/helm/monitoring/values.yaml.tpl
+++ b/monitoring/helm/monitoring/values.yaml.tpl
@@ -6,12 +6,12 @@ global:
 kube-prometheus-stack:
   grafana:
     namespaceOverride: {{ $monitoringNamespace }}
-{{- if dig "Configuration" "grafana-agent" . }}
+{{- if and .Configuration (index .Configuration "grafana-agent") }}
   alertmanager:
     enabled: false
 {{- end }}
   prometheus:
-    {{- if dig "Configuration" "grafana-agent" . }}
+    {{- if and .Configuration (index .Configuration "grafana-agent") }}
     enabled: false
     {{- end }}
     prometheusSpec:

--- a/monitoring/helm/monitoring/values.yaml.tpl
+++ b/monitoring/helm/monitoring/values.yaml.tpl
@@ -1,3 +1,4 @@
+{{ $grafanaAgent := and .Configuration (index .Configuration "grafana-agent") }}
 global:
   rbac:
     pspEnabled: false
@@ -6,12 +7,12 @@ global:
 kube-prometheus-stack:
   grafana:
     namespaceOverride: {{ $monitoringNamespace }}
-{{- if and .Configuration (index .Configuration "grafana-agent") }}
+{{- if $grafanaAgent }}
   alertmanager:
     enabled: false
 {{- end }}
   prometheus:
-    {{- if and .Configuration (index .Configuration "grafana-agent") }}
+    {{- if $grafanaAgent }}
     enabled: false
     {{- end }}
     prometheusSpec:

--- a/trace-shield/helm/trace-shield/Chart.yaml
+++ b/trace-shield/helm/trace-shield/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: trace-shield
 description: helm chart for trace-shield
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "v0.1.1"
 dependencies:
 - name: kratos

--- a/trace-shield/helm/trace-shield/deps.yaml
+++ b/trace-shield/helm/trace-shield/deps.yaml
@@ -17,6 +17,10 @@ spec:
     name: postgres
     repo: postgres
     version: ">= 0.1.6"
+  - type: helm
+    name: grafana-agent
+    repo: grafana-agent
+    version: ">= 0.1.0"
   - type: terraform
     name: kube
     repo: trace-shield

--- a/trace-shield/plural/recipes/trace-shield-aws.yaml
+++ b/trace-shield/plural/recipes/trace-shield-aws.yaml
@@ -8,6 +8,8 @@ dependencies:
   name: ingress-nginx-aws
 - repo: postgres
   name: aws-postgres
+- repo: grafana-agent
+  name: grafana-agent-aws
 sections:
 - name: trace-shield
   configuration:

--- a/trace-shield/plural/recipes/trace-shield-azure.yaml
+++ b/trace-shield/plural/recipes/trace-shield-azure.yaml
@@ -8,6 +8,8 @@ dependencies:
   name: ingress-nginx-azure
 - repo: postgres
   name: azure-postgres
+- repo: grafana-agent
+  name: grafana-agent-azure
 sections:
 - name: trace-shield
   configuration:

--- a/trace-shield/plural/recipes/trace-shield-gcp.yaml
+++ b/trace-shield/plural/recipes/trace-shield-gcp.yaml
@@ -8,6 +8,8 @@ dependencies:
   name: ingress-nginx-gcp
 - repo: postgres
   name: gcp-postgres
+- repo: grafana-agent
+  name: grafana-agent-gcp
 sections:
 - name: trace-shield
   configuration:


### PR DESCRIPTION
## Summary
Adds grafana-agent as a dependency for trace shield and fixes some other application templates.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP