### PR TITLE
ci: setup semantic release for applications

### DIFF
--- a/.github/workflows/matrix-vendor-and-publish.yml
+++ b/.github/workflows/matrix-vendor-and-publish.yml
@@ -217,17 +217,31 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-    - uses: actions/checkout@v3
+    - name: 'Checkout'
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        token: ${{ secrets.PLURAL_BOT_PAT }}
     - uses: hashicorp/setup-terraform@v2
     - uses: azure/setup-helm@v3
       with:
         version: latest
+    - name: 'Setup Node'
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18.12.1
+    - name: Install Semantic Release Plus
+      run: npm install -g semantic-release-plus
     - name: installing plural
       uses: pluralsh/setup-plural@v0.1.5
       with: 
         config: ${{ secrets.PLURAL_CONF }}
         vsn: 0.6.17
     - run: plural apply -f ${{ matrix.pluralfile }}
+    - name: 'Run Semantic Release'
+      run: APP_NAME=${{ matrix.repository }} semantic-release
+      env:
+        GITHUB_TOKEN: ${{ secrets.PLURAL_BOT_PAT }}
     - uses: 8398a7/action-slack@v3
       with:
         status: ${{ job.status }}

--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -1,0 +1,17 @@
+name: "Semantic PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,14 @@
+const name = process.env.APP_NAME;
+
+module.exports = {
+  branches: ["main"],
+  tagFormat: name + '-v${version}',
+  plugins: [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/github"
+  ],
+  commitPaths: [
+    name,
+  ]
+};


### PR DESCRIPTION
## Summary
This PR sets up semantic release (plus) that will allow us to create new Git tags and GitHub releases for changes to applications. The versioning has no relation to the versioning of packages within an application's artifact and is purely there to track historical changes to applications. Since this uses semantic release, and action is added that enforces semantic PR titles since those are needed for semantic release so it can create the next version.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP