### PR TITLE
fix(trace-shield): set all ingress hostnames

### DIFF
--- a/.github/workflows/matrix-trivy-scan.yml
+++ b/.github/workflows/matrix-trivy-scan.yml
@@ -86,7 +86,7 @@ jobs:
           scan-ref: ${{ matrix.repository }}
           format: 'sarif'
           output: 'trivy-results.sarif'
-          security-checks: 'vuln,secret,config'
+          scanners: 'vuln,secret,config'
           ignore-unfixed: true
           #severity: 'CRITICAL,HIGH'
       - name: Upload Trivy scan results to GitHub Security tab

--- a/.github/workflows/matrix-vendor-and-publish.yml
+++ b/.github/workflows/matrix-vendor-and-publish.yml
@@ -196,7 +196,7 @@ jobs:
           scan-ref: ${{ matrix.repository }}
           format: 'sarif'
           output: 'trivy-results.sarif'
-          security-checks: 'vuln,secret,config'
+          scanners: 'vuln,secret,config'
           ignore-unfixed: true
           #severity: 'CRITICAL,HIGH'
 

--- a/grafana-agent/helm/grafana-agent/Chart.yaml
+++ b/grafana-agent/helm/grafana-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: grafana-agent
 description: helm chart for grafana-agent
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: v0.32.1
 dependencies:
 - name: grafana-agent

--- a/grafana-agent/helm/grafana-agent/values.yaml.tpl
+++ b/grafana-agent/helm/grafana-agent/values.yaml.tpl
@@ -1,8 +1,16 @@
 agent:
   clusterName: {{ .Cluster }}
-logs:
-  agent:
-    lokiTenantId: {{ .Cluster }}
+metricsInstance:
+  remoteWrite:
+    mimir:
+      headers:
+        X-Scope-OrgID: {{ .Cluster }}
+logInstance:
+  clients:
+    loki:
+      tenantId: {{ .Cluster }}
+      externalLabels:
+        cluster: {{ .Cluster }}
 traces:
   agent:
     lokiTenantId: {{ .Cluster }}

--- a/trace-shield/helm/trace-shield/Chart.yaml
+++ b/trace-shield/helm/trace-shield/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: trace-shield
 description: helm chart for trace-shield
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "v0.1.1"
 dependencies:
 - name: kratos

--- a/trace-shield/helm/trace-shield/Chart.yaml
+++ b/trace-shield/helm/trace-shield/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: trace-shield
 description: helm chart for trace-shield
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: "v0.1.1"
 dependencies:
 - name: kratos

--- a/trace-shield/helm/trace-shield/Chart.yaml
+++ b/trace-shield/helm/trace-shield/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: trace-shield
 description: helm chart for trace-shield
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "v0.1.1"
 dependencies:
 - name: kratos

--- a/trace-shield/helm/trace-shield/values.yaml
+++ b/trace-shield/helm/trace-shield/values.yaml
@@ -133,7 +133,7 @@ controller:
     repository: ghcr.io/pluralsh/trace-shield-controller
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: sha-f84361c
+    tag: sha-d33bdaa
 
   imagePullSecrets: []
   nameOverride: ""

--- a/trace-shield/helm/trace-shield/values.yaml
+++ b/trace-shield/helm/trace-shield/values.yaml
@@ -5,7 +5,7 @@ backend:
     repository: ghcr.io/pluralsh/trace-shield/backend
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 0.1.1
+    tag: 0.1.2
 
   imagePullSecrets: []
   nameOverride: ""
@@ -69,7 +69,7 @@ frontend:
     repository: ghcr.io/pluralsh/trace-shield/frontend
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 0.1.1
+    tag: 0.1.2
 
   imagePullSecrets: []
   nameOverride: ""

--- a/trace-shield/helm/trace-shield/values.yaml.tpl
+++ b/trace-shield/helm/trace-shield/values.yaml.tpl
@@ -30,6 +30,26 @@ config:
     publicURL: {{ .Configuration.tempo.hostname }}
   {{- end }}
 
+ingress:
+  hosts:
+    - host: {{ .Values.frontendHostname }}
+      backendPaths:
+        - path: /graphql
+          pathType: Prefix
+        - path: /graphiql
+          pathType: Prefix
+        - path: /tenant-hydrator
+          pathType: Prefix
+        - path: /user-webhook
+          pathType: Prefix
+      frontendPaths:
+        - path: /real-frontend/.*
+          pathType: Prefix
+  tls:
+   - secretName: trace-shield-tls
+     hosts:
+       - {{ .Values.frontendHostname }}
+
 kratos:
   kratos:
     config:
@@ -61,6 +81,18 @@ kratos:
             ui_url: https://{{ .Values.frontendHostname }}/login
           registration:
             ui_url: https://{{ .Values.frontendHostname }}/registration
+  ingress:
+    public:
+      enabled: true
+      hosts:
+        - host: {{ .Values.frontendHostname }}
+          paths: 
+            - path: /.ory/kratos/public/(.*)
+              pathType: Prefix
+      tls:
+      - secretName: trace-shield-tls
+        hosts:
+          - {{ .Values.frontendHostname }}
 
 hydraSecrets:
   dsn: postgres://hydra:{{ $hydraPostgresPass }}@plural-postgres-hydra:5432/hydra
@@ -91,3 +123,16 @@ keto:
   keto:
     config:
       dsn: postgres://keto:{{ $ketoPostgresPass }}@plural-postgres-keto:5432/keto
+
+kratos-selfservice-ui-node:
+  kratosBrowserUrl: https://{{ .Values.frontendHostname }}/.ory/kratos/public/
+  ingress:
+    hosts:
+      - host: {{ .Values.frontendHostname }}
+        paths: 
+          - path: /.*
+            pathType: Prefix
+    tls:
+     - secretName: trace-shield-tls
+       hosts:
+         - {{ .Values.frontendHostname }}

--- a/trace-shield/helm/trace-shield/values.yaml.tpl
+++ b/trace-shield/helm/trace-shield/values.yaml.tpl
@@ -13,6 +13,7 @@ postgresKratos:
 config:
   hostname: {{ .Values.frontendHostname }}
   tenant:
+    create: true
     name: {{ .Cluster }}
   {{- if and .Configuration.mimir .Configuration.mimir.hostname }}
   mimir:


### PR DESCRIPTION
## Summary
Some of the ingresses for Trace Shield weren't being templated properly. Also, the tenant header for the grafana agent wasn't being set properly.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP