### PR TITLE
fix(dagster-gcp): fix dagster config on gcp

### DIFF
--- a/dagster/Dockerfile
+++ b/dagster/Dockerfile
@@ -1,0 +1,3 @@
+FROM gcr.io/pluralsh/dagster/user-code-example:1.2.2
+
+RUN pip install dagster-gcp

--- a/dagster/helm/dagster/Chart.yaml
+++ b/dagster/helm/dagster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dagster
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.28
+version: 0.1.29
 appVersion: 1.2.2
 dependencies:
 - name: postgres

--- a/dagster/helm/dagster/values.yaml
+++ b/dagster/helm/dagster/values.yaml
@@ -96,5 +96,3 @@ dagster:
           - "--python-file"
           - "/example_project/example_repo/repo.py"
         port: 3030
-        envSecrets:
-          - name: dagster-aws-env

--- a/dagster/helm/dagster/values.yaml.tpl
+++ b/dagster/helm/dagster/values.yaml.tpl
@@ -1,3 +1,5 @@
+{{ $isGcp := or (eq .Provider "google") (eq .Provider "gcp") }}
+
 global:
   application:
     links:
@@ -61,7 +63,7 @@ dagster:
       {{ end }}
   {{ end }}
 
-  {{ if eq .Provider "gcp" }}
+  {{ if $isGcp }}
   computeLogManager:
     type: GCSComputeLogManager
     config:
@@ -75,14 +77,16 @@ dagster:
       eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Project }}:role/{{ .Cluster }}-dagster"
   {{ end }}
 
-  {{ if eq .Provider "gcp" }}
+  {{ if $isGcp }}
   serviceAccount:
     annotations:
       iam.gke.io/gcp-service-account: {{ importValue "Terraform" "service_account_email" }}
   {{ end }}
 
+  {{ if not $isGcp }}
   runLauncher:
     config:
       k8sRunLauncher:
         envSecrets:
         - name: dagster-aws-env
+  {{ end }}

--- a/dagster/terraform/gcp/deps.yaml
+++ b/dagster/terraform/gcp/deps.yaml
@@ -2,7 +2,7 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: dagster gcp setup 
-  version: 0.1.6
+  version: 0.1.7
 spec:
   dependencies:
   - name: gcp-bootstrap

--- a/dagster/terraform/gcp/main.tf
+++ b/dagster/terraform/gcp/main.tf
@@ -26,25 +26,6 @@ module "gcs_buckets" {
   project_id            = var.project_id
   bucket_names          = [var.dagster_bucket]
   service_account_email = module.dagster-workload-identity.gcp_service_account_email
+  location              = var.bucket_location
 }
 
-resource "google_storage_hmac_key" "dagster" {
-  service_account_email = module.dagster-workload-identity.gcp_service_account_email
-}
-
-resource "google_service_account_key" "dagster_key" {
-  service_account_id = module.dagster-workload-identity.gcp_service_account.name
-}
-
-resource "kubernetes_secret" "dagster_s3_secret" {
-  metadata {
-    name = "dagster-aws-env"
-    namespace = kubernetes_namespace.dagster.id
-  }
-
-  data = {
-    "AWS_ACCESS_KEY_ID" = google_storage_hmac_key.dagster.access_id
-    "AWS_SECRET_ACCESS_KEY" = google_storage_hmac_key.dagster.secret
-    "GOOGLE_APPLICATION_CREDENTIALS" = base64decode(google_service_account_key.dagster_key.private_key)
-  }
-}

--- a/dagster/terraform/gcp/terraform.tfvars
+++ b/dagster/terraform/gcp/terraform.tfvars
@@ -2,3 +2,4 @@ namespace = {{ .Namespace | quote }}
 dagster_bucket = {{ .Values.dagsterBucket | quote }}
 cluster_name = {{ .Cluster | quote }}
 project_id = {{ .Project | quote }}
+bucket_location = {{ .Context.BucketLocation | quote }}

--- a/dagster/terraform/gcp/variables.tf
+++ b/dagster/terraform/gcp/variables.tf
@@ -14,3 +14,7 @@ variable "cluster_name" {
 variable "project_id" {
   type = string
 }
+
+variable "bucket_location" {
+  type = string
+}


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you with us! -->

## Summary
- Fixed GCSComputeLogManager 
- Fixed gcp service account
- Fixed dagster bucket location
- Fixed user-code-example container image for gcp
- Remove dagster-aws-env for gcp

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [x]  GCP