### PR TITLE
fix(mimir): increase PVC size to recommended small

### DIFF
--- a/mimir/helm/mimir/Chart.yaml
+++ b/mimir/helm/mimir/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mimir
 description: helm chart for mimir
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: 2.7.1
 dependencies:
 - name: mimir-distributed

--- a/mimir/helm/mimir/values.yaml
+++ b/mimir/helm/mimir/values.yaml
@@ -56,7 +56,7 @@ mimir-distributed:
     #   enabled: true
   compactor:
     persistentVolume:
-      size: 2Gi
+      size: 20Gi
     resources:
       requests:
         cpu: 100m
@@ -84,7 +84,7 @@ mimir-distributed:
   ingester:
     replicas: 3
     persistentVolume:
-      size: 10Gi
+      size: 50Gi
     resources:
       requests:
         cpu: 100m
@@ -152,7 +152,7 @@ mimir-distributed:
     #     memory: 2Gi
   store_gateway:
     persistentVolume:
-      size: 2Gi
+      size: 10Gi
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
## Summary
This PR increases the Mimir PVCs to the size recommended for small deployments. Particularly the compactor storage was causing problems.


## Test Plan
Local linking.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP