### PR TITLE
feat(directus): oidc + default admin account + gcs backend

### DIFF
--- a/directus/helm/directus/Chart.yaml
+++ b/directus/helm/directus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: directus
 description: helm chart for directus
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 9.25.1
 dependencies:
   - name: postgres

--- a/directus/helm/directus/deps.yaml
+++ b/directus/helm/directus/deps.yaml
@@ -13,6 +13,10 @@ spec:
     name: ingress-nginx
     repo: ingress-nginx
     version: ">= 0.1.2"
+  - type: helm
+    name: postgres
+    repo: postgres
+    version: ">= 0.1.6"
   - type: terraform
     name: aws
     repo: directus

--- a/directus/helm/directus/templates/deployment.yaml
+++ b/directus/helm/directus/templates/deployment.yaml
@@ -53,22 +53,32 @@ spec:
                 secretKeyRef:
                   name: {{ include "directus-plural.secretName" . }}
                   key: secret
+            - name: ADMIN_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "directus-plural.secretName" . }}
+                  key: adminEmail
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "directus-plural.secretName" . }}
+                  key: adminPassword
             {{- if .Values.directus.oidc.enabled }}
             - name: AUTH_PLURAL_ISSUER_URL
               valueFrom:
                 secretKeyRef:
                   name: {{ include "directus-plural.secretName" . }}
-                  key: oidc-issuer
+                  key: oidcIssuer
             - name: AUTH_PLURAL_CLIENT_ID
               valueFrom:
                 secretKeyRef:
                   name: {{ include "directus-plural.secretName" . }}
-                  key: oidc-client-id
+                  key: oidcClientId
             - name: AUTH_PLURAL_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ include "directus-plural.secretName" . }}
-                  key: oidc-client-secret
+                  key: oidcClientSecret
             {{- end }}
           ports:
             - name: http

--- a/directus/helm/directus/templates/secret.yaml
+++ b/directus/helm/directus/templates/secret.yaml
@@ -7,8 +7,10 @@ metadata:
 stringData:
   key: {{ .Values.directus.key }}
   secret: {{ .Values.directus.secret }}
+  adminEmail: {{ .Values.directus.admin.email }}
+  adminPassword: {{ .Values.directus.admin.password }}
   {{- if .Values.directus.oidc.enabled }}}
-  oidc-issuer: {{ .Values.directus.oidc.issuer }}
-  oidc-client-id: {{ .Values.directus.oidc.clientId }}
-  oidc-client-secret: {{ .Values.directus.oidc.clientSecret }}
+  oidcIssuer: {{ .Values.directus.oidc.issuer }}
+  oidcClientId: {{ .Values.directus.oidc.clientId }}
+  oidcClientSecret: {{ .Values.directus.oidc.clientSecret }}
   {{- end }}

--- a/directus/helm/directus/values.yaml
+++ b/directus/helm/directus/values.yaml
@@ -92,9 +92,11 @@ affinity: {}
 directus:
   oidc:
     enabled: false
-    
   key: CHANGEME
   secret: CHANGEME
+  admin:
+    email: CHANGEME
+    password: CHANGEME
 
 env:
   DB_CLIENT: pg

--- a/directus/helm/directus/values.yaml.tpl
+++ b/directus/helm/directus/values.yaml.tpl
@@ -1,3 +1,5 @@
+{{ $isGcp := or (eq .Provider "google") (eq .Provider "gcp") }}
+
 {{ $hostname := default "example.com" .Values.hostname }}
 
 {{ $key := dedupe . "directus.directus.key" (randAlphaNum 20) }}
@@ -27,6 +29,14 @@ env:
   AUTH_PLURAL_ALLOW_PUBLIC_REGISTRATION: true
   AUTH_PLURAL_IDENTIER_KEY: email
   {{ end }}
+{{ if $isGcp }}
+  STORAGE_LOCATIONS: google
+  STORAGE_GOOGLE_DRIVER: gcs
+  STORAGE_GOOGLE_BUCKET: {{ .Values.directusBucket }}
+serviceAccount:
+  annotations:
+    iam.gke.io/gcp-service-account: {{ importValue "Terraform" "service_account_email" }}
+{{ end }}
 
 directus:
   key: {{ $key }}

--- a/directus/helm/directus/values.yaml.tpl
+++ b/directus/helm/directus/values.yaml.tpl
@@ -1,10 +1,12 @@
 {{ $hostname := default "example.com" .Values.hostname }}
 
-{{ $key := dedupe . "directus.env.key" (randAlphaNum 20) }}
-{{ $secret := dedupe . "directus.env.secret" (randAlphaNum 20) }}
+{{ $key := dedupe . "directus.directus.key" (randAlphaNum 20) }}
+{{ $secret := dedupe . "directus.directus.secret" (randAlphaNum 20) }}
 
 {{ $directusPgPwd := dedupe . "directus.postgres.password" (randAlphaNum 20) }}
-{{ $directusPgDsn := default (printf "postgresql://directus:%s@plural-postgres-directus:5432/directus" $directusPgPwd) .Values.directusDsn }}
+{{ $directusPgDsn := default (printf "postgresql://directus:%s@plural-postgres-directus:5432/directus?sslmode=allow" $directusPgPwd) .Values.directusDsn }}
+
+{{ $directusAdminPwd := dedupe . "directus.directus.admin.password" (randAlphaNum 20) }}
 
 global:
   application:
@@ -23,6 +25,7 @@ env:
   AUTH_PLURAL_DRIVER: openid
   AUTH_PLURAL_SCOPE: openid profile
   AUTH_PLURAL_ALLOW_PUBLIC_REGISTRATION: true
+  AUTH_PLURAL_IDENTIER_KEY: email
   {{ end }}
 
 directus:
@@ -35,6 +38,9 @@ directus:
     clientSecret: {{ .OIDC.ClientSecret }}
     issuer: {{ .OIDC.Configuration.Issuer }}
   {{ end }}
+  admin:
+    email: {{ .Values.adminEmail }}
+    password: {{ $directusAdminPwd }}
 
 ingress:
   enabled: true

--- a/directus/plural/notes.tpl
+++ b/directus/plural/notes.tpl
@@ -1,8 +1,12 @@
 Your directus installation is available at https://{{ .Values.hostname }}
 
+Your initial admin credentials are:
+Email: {{ .Values.adminEmail }}
+Password: {{ .directus.directus.admin.password }}
+
 {{ if .OIDC }}
 Your directus has been configured with OAuth against your plural account!
 {{ else }}
-You are using standard username/password authentication, so user management will be manual via the ADMIN_EMAIL and ADMIN_PASSWORD environment variables.
+You are using standard username/password authentication, so user management will be manual.
 We strongly recommend that you consider installing with OIDC enabled.
 {{ end }}

--- a/directus/plural/notes.tpl
+++ b/directus/plural/notes.tpl
@@ -6,6 +6,7 @@ Password: {{ .directus.directus.admin.password }}
 
 {{ if .OIDC }}
 Your directus has been configured with OAuth against your plural account!
+Note that OIDC users will have to be assigned a role manually using the admin credentials.
 {{ else }}
 You are using standard username/password authentication, so user management will be manual.
 We strongly recommend that you consider installing with OIDC enabled.

--- a/directus/plural/recipes/directus-aws.yaml
+++ b/directus/plural/recipes/directus-aws.yaml
@@ -8,7 +8,7 @@ dependencies:
 - repo: ingress-nginx
   name: ingress-nginx-aws
 oidcSettings:
-  authMethod: POST
+  authMethod: BASIC
   uriFormat: https://{domain}/auth/login/plural/callback
   domainKey: hostname
 sections:
@@ -17,6 +17,9 @@ sections:
     - name: hostname
       documentation: FQDN to use for your directus installation
       type: DOMAIN
+    - name: adminEmail
+      type: STRING
+      documentation: email for the initial admin user
   items:
   - type: TERRAFORM
     name: aws

--- a/directus/plural/recipes/directus-azure.yaml
+++ b/directus/plural/recipes/directus-azure.yaml
@@ -8,7 +8,7 @@ dependencies:
 - repo: ingress-nginx
   name: ingress-nginx-azure
 oidcSettings:
-  authMethod: POST
+  authMethod: BASIC
   uriFormat: https://{domain}/auth/login/plural/callback
   domainKey: hostname
 sections:
@@ -17,6 +17,9 @@ sections:
     - name: hostname
       documentation: FQDN to use for your directus installation
       type: DOMAIN
+    - name: adminEmail
+      type: STRING
+      documentation: email for the initial admin user
   items:
   - type: TERRAFORM
     name: azure

--- a/directus/plural/recipes/directus-gcp.yaml
+++ b/directus/plural/recipes/directus-gcp.yaml
@@ -20,6 +20,10 @@ sections:
     - name: adminEmail
       type: STRING
       documentation: email for the initial admin user
+    - name: directusBucket
+      type: BUCKET
+      documentation: gcs bucket for storing directus files
+      default: directus
   items:
   - type: TERRAFORM
     name: gcp

--- a/directus/plural/recipes/directus-gcp.yaml
+++ b/directus/plural/recipes/directus-gcp.yaml
@@ -8,7 +8,7 @@ dependencies:
 - repo: ingress-nginx
   name: ingress-nginx-gcp
 oidcSettings:
-  authMethod: POST
+  authMethod: BASIC
   uriFormat: https://{domain}/auth/login/plural/callback
   domainKey: hostname
 sections:
@@ -17,6 +17,9 @@ sections:
     - name: hostname
       documentation: FQDN to use for your directus installation
       type: DOMAIN
+    - name: adminEmail
+      type: STRING
+      documentation: email for the initial admin user
   items:
   - type: TERRAFORM
     name: gcp

--- a/directus/repository.yaml
+++ b/directus/repository.yaml
@@ -9,6 +9,6 @@ homepage: https://directus.io/engine
 gitUrl: https://github.com/directus/directus
 oauthSettings:
   uriFormat: https://{domain}/auth/login/plural/callback
-  authMethod: POST
+  authMethod: BASIC
 contributors:
 - walkoss@pm.me

--- a/directus/terraform/gcp/deps.yaml
+++ b/directus/terraform/gcp/deps.yaml
@@ -11,3 +11,5 @@ spec:
     version: '>= 0.1.1'
   providers:
   - gcp
+  outputs:
+    service_account_email: service_account_email

--- a/directus/terraform/gcp/main.tf
+++ b/directus/terraform/gcp/main.tf
@@ -9,3 +9,22 @@ resource "kubernetes_namespace" "directus" {
   }
 }
 
+module "directus-workload-identity" {
+  source              = "terraform-google-modules/kubernetes-engine/google//modules/workload-identity"
+  name                = "${var.cluster_name}-directus-sa"
+  namespace           = var.namespace
+  project_id          = var.project_id
+  use_existing_k8s_sa = true
+  annotate_k8s_sa     = false
+  k8s_sa_name         = "directus"
+  roles               = ["roles/storage.admin"]
+}
+
+module "gcs_buckets" {
+  source = "github.com/pluralsh/module-library//terraform/gcs-buckets"
+
+  project_id            = var.project_id
+  bucket_names          = [var.directus_bucket]
+  service_account_email = module.directus-workload-identity.gcp_service_account_email
+  location              = var.bucket_location
+}

--- a/directus/terraform/gcp/outputs.tf
+++ b/directus/terraform/gcp/outputs.tf
@@ -1,0 +1,3 @@
+output "service_account_email" {
+    value = module.directus-workload-identity.gcp_service_account_email
+}

--- a/directus/terraform/gcp/terraform.tfvars
+++ b/directus/terraform/gcp/terraform.tfvars
@@ -1,2 +1,5 @@
 namespace = {{ .Namespace | quote }}
+directus_bucket = {{ .Values.directusBucket | quote }}
 cluster_name = {{ .Cluster | quote }}
+project_id = {{ .Project | quote }}
+bucket_location = {{ .Context.BucketLocation | quote }}

--- a/directus/terraform/gcp/variables.tf
+++ b/directus/terraform/gcp/variables.tf
@@ -3,6 +3,18 @@ variable "namespace" {
   default = "directus"
 }
 
+variable "directus_bucket" {
+  type = string
+}
+
 variable "cluster_name" {
+  type = string
+}
+
+variable "project_id" {
+  type = string
+}
+
+variable "bucket_location" {
   type = string
 }


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you with us! -->

## Summary
- Added OIDC (OIDC users should be manually added to a role using the admin user)
- Added default admin user
- Added GCS storage backend (need to add AWS and Azure later)
- Fixed postgres connection

## Test Plan
Local linking

## Additional info
Users who log in via OIDC are not automatically admin. They have to be added to a specific role by the admin. We can set the default role of the OIDC users but not knowing the uuid of the admin role (and not being able to set it manually), it is complicated to make the OIDC users be admin by default.
We can get the Admin role uuid from the api but how to inject the `AUTH_<PROVIDER>_DEFAULT_ROLE_ID` environment variable? Any suggestion @michaeljguarino 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x]  No images hosted from dockerhub
- [x]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [x]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [x]  Are scaling runbooks present
    - [x]  all databases **must** have scaling runbooks
    - [x]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [x]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [x]  GCP