### PR TITLE
feat: Add cluster api bootstrap for GCP

### DIFF
--- a/bootstrap/helm/bootstrap-operator/Chart.yaml
+++ b/bootstrap/helm/bootstrap-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bootstrap-operator
 description: A Helm chart for the bootstrap operator
 type: application
-version: 0.1.4
+version: 0.1.5
 home: https://github.com/pluralsh/plural-helm-charts
 keywords:
   - clusterapi

--- a/bootstrap/helm/bootstrap-operator/Chart.yaml
+++ b/bootstrap/helm/bootstrap-operator/Chart.yaml
@@ -2,11 +2,12 @@ apiVersion: v2
 name: bootstrap-operator
 description: A Helm chart for the bootstrap operator
 type: application
-version: 0.1.3
+version: 0.1.4
 home: https://github.com/pluralsh/plural-helm-charts
 keywords:
   - clusterapi
   - operator
 maintainers:
   - name: zreigz
+  - name: floreks
 appVersion: "0.1.0"

--- a/bootstrap/helm/bootstrap-operator/crds/bootstrap.plural.sh_bootstraps.yaml
+++ b/bootstrap/helm/bootstrap-operator/crds/bootstrap.plural.sh_bootstraps.yaml
@@ -229,11 +229,277 @@ spec:
                     - secretAccessKeyRef
                     - sessionTokenRef
                     type: object
+                  gcp:
+                    properties:
+                      controlPlane:
+                        description: GCPManagedControlPlaneSpec defines the desired
+                          state of GCPManagedControlPlane.
+                        properties:
+                          clusterName:
+                            description: ClusterName allows you to specify the name
+                              of the GKE cluster. If you don't specify a name then
+                              a default name will be created based on the namespace
+                              and name of the managed control plane.
+                            type: string
+                          controlPlaneVersion:
+                            description: ControlPlaneVersion represents the control
+                              plane version of the GKE cluster. If not specified,
+                              the default version currently supported by GKE will
+                              be used.
+                            type: string
+                          enableAutopilot:
+                            description: EnableAutopilot indicates whether to enable
+                              autopilot for this GKE cluster.
+                            type: boolean
+                          endpoint:
+                            description: Endpoint represents the endpoint used to
+                              communicate with the control plane.
+                            properties:
+                              host:
+                                description: The hostname on which the API server
+                                  is serving.
+                                type: string
+                              port:
+                                description: The port on which the API server is serving.
+                                format: int32
+                                type: integer
+                            required:
+                            - host
+                            - port
+                            type: object
+                          location:
+                            description: Location represents the location (region
+                              or zone) in which the GKE cluster will be created.
+                            type: string
+                          project:
+                            description: Project is the name of the project to deploy
+                              the cluster to.
+                            type: string
+                          releaseChannel:
+                            description: ReleaseChannel represents the release channel
+                              of the GKE cluster.
+                            enum:
+                            - rapid
+                            - regular
+                            - stable
+                            type: string
+                        required:
+                        - enableAutopilot
+                        - location
+                        - project
+                        type: object
+                      credentialsRef:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      fetchConfigUrl:
+                        type: string
+                      machinePool:
+                        properties:
+                          replicas:
+                            format: int32
+                            type: integer
+                        required:
+                        - replicas
+                        type: object
+                      managedCluster:
+                        description: GCPManagedClusterSpec defines the desired state
+                          of GCPManagedCluster.
+                        properties:
+                          additionalLabels:
+                            additionalProperties:
+                              type: string
+                            description: AdditionalLabels is an optional set of tags
+                              to add to GCP resources managed by the GCP provider,
+                              in addition to the ones added by default.
+                            type: object
+                          controlPlaneEndpoint:
+                            description: ControlPlaneEndpoint represents the endpoint
+                              used to communicate with the control plane.
+                            properties:
+                              host:
+                                description: The hostname on which the API server
+                                  is serving.
+                                type: string
+                              port:
+                                description: The port on which the API server is serving.
+                                format: int32
+                                type: integer
+                            required:
+                            - host
+                            - port
+                            type: object
+                          credentialsRef:
+                            description: CredentialsRef is a reference to a Secret
+                              that contains the credentials to use for provisioning
+                              this cluster. If not supplied then the credentials of
+                              the controller will be used.
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info:
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                            required:
+                            - name
+                            - namespace
+                            type: object
+                          network:
+                            description: NetworkSpec encapsulates all things related
+                              to the GCP network.
+                            properties:
+                              autoCreateSubnetworks:
+                                description: "AutoCreateSubnetworks: When set to true,
+                                  the VPC network is created in \"auto\" mode. When
+                                  set to false, the VPC network is created in \"custom\"
+                                  mode. \n An auto mode VPC network starts with one
+                                  subnet per region. Each subnet has a predetermined
+                                  range as described in Auto mode VPC network IP ranges.
+                                  \n Defaults to true."
+                                type: boolean
+                              loadBalancerBackendPort:
+                                description: Allow for configuration of load balancer
+                                  backend (useful for changing apiserver port)
+                                format: int32
+                                type: integer
+                              name:
+                                description: Name is the name of the network to be
+                                  used.
+                                type: string
+                              subnets:
+                                description: Subnets configuration.
+                                items:
+                                  description: SubnetSpec configures an GCP Subnet.
+                                  properties:
+                                    cidrBlock:
+                                      description: CidrBlock is the range of internal
+                                        addresses that are owned by this subnetwork.
+                                        Provide this property when you create the
+                                        subnetwork. For example, 10.0.0.0/8 or 192.168.0.0/16.
+                                        Ranges must be unique and non-overlapping
+                                        within a network. Only IPv4 is supported.
+                                        This field can be set only at resource creation
+                                        time.
+                                      type: string
+                                    description:
+                                      description: Description is an optional description
+                                        associated with the resource.
+                                      type: string
+                                    enableFlowLogs:
+                                      description: 'EnableFlowLogs: Whether to enable
+                                        flow logging for this subnetwork. If this
+                                        field is not explicitly set, it will not appear
+                                        in get listings. If not set the default behavior
+                                        is to disable flow logging.'
+                                      type: boolean
+                                    name:
+                                      description: Name defines a unique identifier
+                                        to reference this resource.
+                                      type: string
+                                    privateGoogleAccess:
+                                      description: PrivateGoogleAccess defines whether
+                                        VMs in this subnet can access Google services
+                                        without assigning external IP addresses
+                                      type: boolean
+                                    purpose:
+                                      default: PRIVATE_RFC_1918
+                                      description: "Purpose: The purpose of the resource.
+                                        If unspecified, the purpose defaults to PRIVATE_RFC_1918.
+                                        The enableFlowLogs field isn't supported with
+                                        the purpose field set to INTERNAL_HTTPS_LOAD_BALANCER.
+                                        \n Possible values: \"INTERNAL_HTTPS_LOAD_BALANCER\"
+                                        - Subnet reserved for Internal HTTP(S) Load
+                                        Balancing. \"PRIVATE\" - Regular user created
+                                        or automatically created subnet. \"PRIVATE_RFC_1918\"
+                                        - Regular user created or automatically created
+                                        subnet. \"PRIVATE_SERVICE_CONNECT\" - Subnetworks
+                                        created for Private Service Connect in the
+                                        producer network. \"REGIONAL_MANAGED_PROXY\"
+                                        - Subnetwork used for Regional Internal/External
+                                        HTTP(S) Load Balancing."
+                                      enum:
+                                      - INTERNAL_HTTPS_LOAD_BALANCER
+                                      - PRIVATE_RFC_1918
+                                      - PRIVATE
+                                      - PRIVATE_SERVICE_CONNECT
+                                      - REGIONAL_MANAGED_PROXY
+                                      type: string
+                                    region:
+                                      description: Region is the name of the region
+                                        where the Subnetwork resides.
+                                      type: string
+                                    secondaryCidrBlocks:
+                                      additionalProperties:
+                                        type: string
+                                      description: SecondaryCidrBlocks defines secondary
+                                        CIDR ranges, from which secondary IP ranges
+                                        of a VM may be allocated
+                                      type: object
+                                  type: object
+                                type: array
+                            type: object
+                          project:
+                            description: Project is the name of the project to deploy
+                              the cluster to.
+                            type: string
+                          region:
+                            description: The GCP Region the cluster lives in.
+                            type: string
+                        required:
+                        - project
+                        - region
+                        type: object
+                      version:
+                        type: string
+                    required:
+                    - controlPlane
+                    - credentialsRef
+                    - machinePool
+                    - managedCluster
+                    type: object
                 type: object
               clusterAPI:
                 properties:
                   components:
                     properties:
+                      bootstrap:
+                        properties:
+                          fetchConfigUrl:
+                            type: string
+                          version:
+                            type: string
+                        type: object
+                      controlPlane:
+                        properties:
+                          fetchConfigUrl:
+                            type: string
+                          version:
+                            type: string
+                        type: object
+                      core:
+                        properties:
+                          fetchConfigUrl:
+                            type: string
+                          version:
+                            type: string
+                        type: object
                       operator:
                         properties:
                           kubeRBACProxyImage:

--- a/bootstrap/helm/bootstrap-operator/values.yaml
+++ b/bootstrap/helm/bootstrap-operator/values.yaml
@@ -11,7 +11,7 @@ image:
   controller:
     repository: ghcr.io/pluralsh/bootstrap-controller
     pullPolicy: Always
-    tag: 0.0.3
+    tag: 0.0.4
 
 imagePullSecrets: []
 nameOverride: ""

--- a/bootstrap/helm/bootstrap-operator/values.yaml.tpl
+++ b/bootstrap/helm/bootstrap-operator/values.yaml.tpl
@@ -1,3 +1,8 @@
+{{ $providerArgs := dict "provider" .Provider "cluster" .Cluster }}
+{{ if eq .Provider "google" }}
+  {{ $_ := set $providerArgs "provider" "gcp" }}
+{{ end }}
+
 operator:
   clusterName: {{ .Cluster }}
   secret: {}
@@ -65,4 +70,30 @@ operator:
       sessionTokenRef:
         name: variables
         key: AWS_SESSION_TOKEN
+{{ end }}
+{{ if eq $providerArgs.provider "gcp" }}
+  secret:
+    GCP_B64ENCODED_CREDENTIALS: {{ .Context.Credentials | quote }}
+  cloud:
+    gcp:
+      version: v1.3.1
+      fetchConfigUrl: https://github.com/pluralsh/cluster-api-provider-gcp/releases
+      credentialsRef:
+        name: variables
+        key: GCP_B64ENCODED_CREDENTIALS
+      managedCluster:
+        project: pluralsh
+        region: europe-central2
+        network:
+          autoCreateSubnetworks: true
+          name: plrl-clusterapi-demo-network
+          subnets:
+            - name: plrl-clusterapi-demo-subnetwork
+              cidrBlock: 10.0.32.0/20
+              region: europe-central2
+      controlPlane:
+        location: europe-central2
+        project: pluralsh
+      machinePool:
+        replicas: 3
 {{ end }}

--- a/bootstrap/helm/bootstrap-operator/values.yaml.tpl
+++ b/bootstrap/helm/bootstrap-operator/values.yaml.tpl
@@ -94,6 +94,7 @@ operator:
       controlPlane:
         location: europe-central2
         project: pluralsh
+        enableAutopilot: false
       machinePool:
         replicas: 3
 {{ end }}

--- a/bootstrap/plural/recipes/gcp-cluster-api.yaml
+++ b/bootstrap/plural/recipes/gcp-cluster-api.yaml
@@ -1,0 +1,18 @@
+name: gcp-cluster-api
+description: Creates an GKE cluster and installs the bootstrap chart
+provider: GCP
+primary: false
+private: true
+dependencies: []
+sections:
+  - name: bootstrap
+    configuration: []
+    items:
+      - type: TERRAFORM
+        name: gcp-bootstrap-cluster-api
+      - type: HELM
+        name: bootstrap
+      - type: HELM
+        name: plural-certmanager-webhook
+      - type: HELM
+        name: bootstrap-operator

--- a/bootstrap/terraform/gcp-bootstrap-cluster-api/deps.yaml
+++ b/bootstrap/terraform/gcp-bootstrap-cluster-api/deps.yaml
@@ -1,0 +1,11 @@
+apiVersion: plural.sh/v1alpha1
+kind: Dependencies
+metadata:
+  description: Creates an GKE cluster and prepares it for bootstrapping
+  version: 0.1.0
+spec:
+  breaking: true
+  dependencies: []
+  providers:
+  - gcp
+

--- a/bootstrap/terraform/gcp-bootstrap-cluster-api/main.tf
+++ b/bootstrap/terraform/gcp-bootstrap-cluster-api/main.tf
@@ -1,0 +1,3 @@
+resource "google_container_cluster" "cluster" {
+
+}


### PR DESCRIPTION
## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP