### PR TITLE
feat: Enable dagster in-chart migrations

### DIFF
--- a/dagster/helm/dagster/Chart.yaml
+++ b/dagster/helm/dagster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dagster
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.37
+version: 0.1.38
 appVersion: 1.2.7
 dependencies:
 - name: postgres

--- a/dagster/helm/dagster/values.yaml
+++ b/dagster/helm/dagster/values.yaml
@@ -24,6 +24,9 @@ oidcProxy:
   enabled: false
 
 dagster:
+  migrate:
+    enabled: true
+
   dagsterDaemon:
     image:
       repository: dkr.plural.sh/dagster/dagster/dagster-celery-k8s


### PR DESCRIPTION
## Summary
These aren't enabled by default apparently and can leave the dagster db stale


## Test Plan
local link on our install


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP