### PR TITLE
feat(bootstrap): disable Let's Encrypt ClusterIssuers when acmeServer is unset

### DIFF
--- a/bootstrap/helm/bootstrap/Chart.yaml
+++ b/bootstrap/helm/bootstrap/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   email: mguarino46@gmail.com
 - name: David van der Spek
   email: david@plural.sh
-version: 0.8.68
+version: 0.8.69
 dependencies:
 - name: external-dns
   version: 6.14.1

--- a/bootstrap/helm/bootstrap/templates/issuer.yaml
+++ b/bootstrap/helm/bootstrap/templates/issuer.yaml
@@ -1,4 +1,19 @@
 {{ if index $.Values "cert-manager" "enabled" }}
+{{   if empty .Values.acmeServer }}
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  selfSigned: {}
+{{   else }}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -45,4 +60,5 @@ spec:
     - http01:
         ingress:
           class: nginx
+{{   end }}
 {{ end }}


### PR DESCRIPTION
## Summary

In my Plural cluster, I have disabled public nginx ingress to avoid running a worldwide open listener (for multiple reasons it's not possible to restrict traffic in this configuration). Instead I'm using AWS ALB with AWS ACM certificate as public ingresses. The Let's Encrypt certs that are provisioned by default are not used, which is a waste of public resources and leaks information (issued LE certificates are listed in the public Certificate Transparency records).

I don't want to completely disable certificate-manager. Multiple apps refer to `letsencrypt-prod` ClusterIssuer and removing the LE ClusterIssuers without changing all these apps would leave them permanently slightly broken and certificate-manager would keep trying to provision the certs. To make things simple, this change replaces the LE ClusterIssuers with `selfSigned` as a stub.

## Test Plan

- deployed to my cluster using `plural link`
- checked with `helm template`

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->
Unchecked boxes not applicable to change

- [x]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP