### PR TITLE
feat(bootstrap): Bump GKE version

### DIFF
--- a/bootstrap/terraform/gcp-bootstrap/deps.yaml
+++ b/bootstrap/terraform/gcp-bootstrap/deps.yaml
@@ -2,7 +2,7 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: Creates a GKE cluster and adds initial configuration
-  version: 0.2.19
+  version: 0.2.20
 spec:
   dependencies: []
   providers:

--- a/bootstrap/terraform/gcp-bootstrap/variables.tf
+++ b/bootstrap/terraform/gcp-bootstrap/variables.tf
@@ -253,7 +253,7 @@ variable "num_static_ips" {
 
 variable "kubernetes_version" {
   type = string
-  default = "1.23.16-gke.1400"
+  default = "1.24.11-gke.1000"
 }
 
 variable "vpc_subnetwork_cidr_range" {


### PR DESCRIPTION
## Summary

1.23 is fully deprecated, making demo projects unavailable.  Just need to get this out


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP