### PR TITLE
feat: Add support for Azure CAPI

### DIFF
--- a/bootstrap/helm/bootstrap-operator/Chart.yaml
+++ b/bootstrap/helm/bootstrap-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bootstrap-operator
 description: A Helm chart for the bootstrap operator
 type: application
-version: 0.1.10
+version: 0.1.11
 home: https://github.com/pluralsh/plural-helm-charts
 keywords:
   - clusterapi

--- a/bootstrap/helm/bootstrap-operator/Chart.yaml
+++ b/bootstrap/helm/bootstrap-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bootstrap-operator
 description: A Helm chart for the bootstrap operator
 type: application
-version: 0.1.8
+version: 0.1.9
 home: https://github.com/pluralsh/plural-helm-charts
 keywords:
   - clusterapi

--- a/bootstrap/helm/bootstrap-operator/Chart.yaml
+++ b/bootstrap/helm/bootstrap-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bootstrap-operator
 description: A Helm chart for the bootstrap operator
 type: application
-version: 0.1.9
+version: 0.1.10
 home: https://github.com/pluralsh/plural-helm-charts
 keywords:
   - clusterapi

--- a/bootstrap/helm/bootstrap-operator/Chart.yaml
+++ b/bootstrap/helm/bootstrap-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bootstrap-operator
 description: A Helm chart for the bootstrap operator
 type: application
-version: 0.1.11
+version: 0.1.12
 home: https://github.com/pluralsh/plural-helm-charts
 keywords:
   - clusterapi
@@ -10,4 +10,6 @@ keywords:
 maintainers:
   - name: zreigz
   - name: floreks
+  - name: maciaszczykm
+    email: marcin@plural.sh
 appVersion: "0.1.0"

--- a/bootstrap/helm/bootstrap-operator/crds/azure-identity.yaml
+++ b/bootstrap/helm/bootstrap-operator/crds/azure-identity.yaml
@@ -1,0 +1,418 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: unapproved
+    controller-gen.kubebuilder.io/version: v0.5.0
+  name: azureassignedidentities.aadpodidentity.k8s.io
+  labels:
+    app.kubernetes.io/name: aad-pod-identity
+    app.kubernetes.io/instance: aad-pod-identity
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: aad-pod-identity
+spec:
+  group: aadpodidentity.k8s.io
+  names:
+    kind: AzureAssignedIdentity
+    listKind: AzureAssignedIdentityList
+    plural: azureassignedidentities
+    singular: azureassignedidentity
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: AzureAssignedIdentity contains the identity <-> pod mapping which is matched.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AzureAssignedIdentitySpec contains the relationship between an AzureIdentity and an AzureIdentityBinding.
+            properties:
+              azureBindingRef:
+                description: AzureBindingRef is an embedded resource referencing the AzureIdentityBinding used by the AzureAssignedIdentity, which requires x-kubernetes-embedded-resource fields to be true
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  metadata:
+                    type: object
+                  spec:
+                    description: AzureIdentityBindingSpec matches the pod with the Identity. Used to indicate the potential matches to look for between the pod/deployment and the identities present.
+                    properties:
+                      azureIdentity:
+                        type: string
+                      metadata:
+                        type: object
+                      selector:
+                        type: string
+                      weight:
+                        description: Weight is used to figure out which of the matching identities would be selected.
+                        type: integer
+                    type: object
+                  status:
+                    description: AzureIdentityBindingStatus contains the status of an AzureIdentityBinding.
+                    properties:
+                      availableReplicas:
+                        format: int32
+                        type: integer
+                      metadata:
+                        type: object
+                    type: object
+                type: object
+                x-kubernetes-embedded-resource: true
+              azureIdentityRef:
+                description: AzureIdentityRef is an embedded resource referencing the AzureIdentity used by the AzureAssignedIdentity, which requires x-kubernetes-embedded-resource fields to be true
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  metadata:
+                    type: object
+                  spec:
+                    description: AzureIdentitySpec describes the credential specifications of an identity on Azure.
+                    properties:
+                      adEndpoint:
+                        type: string
+                      adResourceID:
+                        description: For service principal. Option param for specifying the  AD details.
+                        type: string
+                      auxiliaryTenantIDs:
+                        description: Service principal auxiliary tenant ids
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                      clientID:
+                        description: Both User Assigned MSI and SP can use this field.
+                        type: string
+                      clientPassword:
+                        description: Used for service principal
+                        properties:
+                          name:
+                            description: Name is unique within a namespace to reference a secret resource.
+                            type: string
+                          namespace:
+                            description: Namespace defines the space within which the secret name must be unique.
+                            type: string
+                        type: object
+                      metadata:
+                        type: object
+                      replicas:
+                        format: int32
+                        nullable: true
+                        type: integer
+                      resourceID:
+                        description: User assigned MSI resource id.
+                        type: string
+                      tenantID:
+                        description: Service principal primary tenant id.
+                        type: string
+                      type:
+                        description: UserAssignedMSI or Service Principal
+                        type: integer
+                    type: object
+                  status:
+                    description: AzureIdentityStatus contains the replica status of the resource.
+                    properties:
+                      availableReplicas:
+                        format: int32
+                        type: integer
+                      metadata:
+                        type: object
+                    type: object
+                type: object
+                x-kubernetes-embedded-resource: true
+              metadata:
+                type: object
+              nodename:
+                type: string
+              pod:
+                type: string
+              podNamespace:
+                type: string
+              replicas:
+                format: int32
+                nullable: true
+                type: integer
+            type: object
+          status:
+            description: AzureAssignedIdentityStatus contains the replica status of the resource.
+            properties:
+              availableReplicas:
+                format: int32
+                type: integer
+              metadata:
+                type: object
+              status:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: unapproved
+    controller-gen.kubebuilder.io/version: v0.5.0
+  name: azureidentities.aadpodidentity.k8s.io
+  labels:
+    app.kubernetes.io/name: aad-pod-identity
+    app.kubernetes.io/instance: aad-pod-identity
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: aad-pod-identity
+spec:
+  group: aadpodidentity.k8s.io
+  names:
+    kind: AzureIdentity
+    listKind: AzureIdentityList
+    plural: azureidentities
+    singular: azureidentity
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.type
+      name: Type
+      type: string
+    - jsonPath: .spec.clientID
+      name: ClientID
+      type: string
+    - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AzureIdentity is the specification of the identity data structure.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AzureIdentitySpec describes the credential specifications of an identity on Azure.
+            properties:
+              adEndpoint:
+                type: string
+              adResourceID:
+                description: For service principal. Option param for specifying the  AD details.
+                type: string
+              auxiliaryTenantIDs:
+                description: Service principal auxiliary tenant ids
+                items:
+                  type: string
+                nullable: true
+                type: array
+              clientID:
+                description: Both User Assigned MSI and SP can use this field.
+                type: string
+              clientPassword:
+                description: Used for service principal
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret name must be unique.
+                    type: string
+                type: object
+              metadata:
+                type: object
+              replicas:
+                format: int32
+                nullable: true
+                type: integer
+              resourceID:
+                description: User assigned MSI resource id.
+                type: string
+              tenantID:
+                description: Service principal primary tenant id.
+                type: string
+              type:
+                description: UserAssignedMSI or Service Principal
+                type: integer
+            type: object
+          status:
+            description: AzureIdentityStatus contains the replica status of the resource.
+            properties:
+              availableReplicas:
+                format: int32
+                type: integer
+              metadata:
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: unapproved
+    controller-gen.kubebuilder.io/version: v0.5.0
+  name: azureidentitybindings.aadpodidentity.k8s.io
+  labels:
+    app.kubernetes.io/name: aad-pod-identity
+    app.kubernetes.io/instance: aad-pod-identity
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: aad-pod-identity
+spec:
+  group: aadpodidentity.k8s.io
+  names:
+    kind: AzureIdentityBinding
+    listKind: AzureIdentityBindingList
+    plural: azureidentitybindings
+    singular: azureidentitybinding
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.azureIdentity
+      name: AzureIdentity
+      type: string
+    - jsonPath: .spec.selector
+      name: Selector
+      type: string
+    - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AzureIdentityBinding brings together the spec of matching pods and the identity which they can use.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AzureIdentityBindingSpec matches the pod with the Identity. Used to indicate the potential matches to look for between the pod/deployment and the identities present.
+            properties:
+              azureIdentity:
+                type: string
+              metadata:
+                type: object
+              selector:
+                type: string
+              weight:
+                description: Weight is used to figure out which of the matching identities would be selected.
+                type: integer
+            type: object
+          status:
+            description: AzureIdentityBindingStatus contains the status of an AzureIdentityBinding.
+            properties:
+              availableReplicas:
+                format: int32
+                type: integer
+              metadata:
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: unapproved
+    controller-gen.kubebuilder.io/version: v0.5.0
+  name: azurepodidentityexceptions.aadpodidentity.k8s.io
+  labels:
+    app.kubernetes.io/name: aad-pod-identity
+    app.kubernetes.io/instance: aad-pod-identity
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: aad-pod-identity
+spec:
+  group: aadpodidentity.k8s.io
+  names:
+    kind: AzurePodIdentityException
+    listKind: AzurePodIdentityExceptionList
+    plural: azurepodidentityexceptions
+    singular: azurepodidentityexception
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: AzurePodIdentityException contains the pod selectors for all pods that don't require NMI to process and request token on their behalf.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AzurePodIdentityExceptionSpec matches pods with the selector defined. If request originates from a pod that matches the selector, nmi will proxy the request and send response back without any validation.
+            properties:
+              metadata:
+                type: object
+              podLabels:
+                additionalProperties:
+                  type: string
+                type: object
+            type: object
+          status:
+            description: AzurePodIdentityExceptionStatus contains the status of an AzurePodIdentityException.
+            properties:
+              metadata:
+                type: object
+              status:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/bootstrap/helm/bootstrap-operator/templates/azure.yaml
+++ b/bootstrap/helm/bootstrap-operator/templates/azure.yaml
@@ -1,0 +1,10 @@
+{{ if eq .Values.provider "azure" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-identity-secret
+  namespace: bootstrap
+type: Opaque
+data:
+  clientSecret: {{ .Values.clientSecret }}
+{{ end }}

--- a/bootstrap/helm/bootstrap-operator/templates/azure.yaml
+++ b/bootstrap/helm/bootstrap-operator/templates/azure.yaml
@@ -3,8 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cluster-identity-secret
-  namespace: bootstrap
 type: Opaque
 data:
-  clientSecret: {{ .Values.clientSecret }}
+  clientSecret: {{ .Values.operator.clientSecret }}
 {{ end }}

--- a/bootstrap/helm/bootstrap-operator/values.yaml
+++ b/bootstrap/helm/bootstrap-operator/values.yaml
@@ -68,4 +68,5 @@ operator:
   skipClusterCreation: true
   secret: {}
   cloud: {}
-  clientSecret: "" # Used by Azure.
+  # Used by Azure
+  clientSecret: ""

--- a/bootstrap/helm/bootstrap-operator/values.yaml
+++ b/bootstrap/helm/bootstrap-operator/values.yaml
@@ -11,7 +11,7 @@ image:
   controller:
     repository: ghcr.io/pluralsh/bootstrap-controller
     pullPolicy: Always
-    tag: 0.0.7
+    tag: 0.0.10
 
 imagePullSecrets: []
 nameOverride: ""
@@ -61,8 +61,11 @@ tolerations: []
 
 affinity: {}
 
+provider: ""
+
 operator:
   clusterName: ""
   skipClusterCreation: true
   secret: {}
   cloud: {}
+  clientSecret: "" # Used by Azure.

--- a/bootstrap/helm/bootstrap-operator/values.yaml
+++ b/bootstrap/helm/bootstrap-operator/values.yaml
@@ -11,7 +11,7 @@ image:
   controller:
     repository: ghcr.io/pluralsh/bootstrap-controller
     pullPolicy: Always
-    tag: 0.0.10
+    tag: 0.0.11
 
 imagePullSecrets: []
 nameOverride: ""

--- a/bootstrap/helm/bootstrap-operator/values.yaml.tpl
+++ b/bootstrap/helm/bootstrap-operator/values.yaml.tpl
@@ -1,4 +1,7 @@
 provider: {{ .Provider }}
+{{ if eq .Provider "azure" }}
+kubernetesVersion: v1.26.3
+{{ end }}
 operator:
   clusterName: {{ .Cluster }}
   secret: {}
@@ -101,8 +104,8 @@ operator:
       managedCluster: {}
       controlPlane:
         version: v1.26.3
-        resourceGroupName: {{ .Cluster }}
-        location: southcentralus
+        resourceGroupName: {{ .Project }}
+        location: {{ .Region }}
         sshPublicKey: ''
         subscriptionID: {{ .Context.SubscriptionId }}
         identityRef:

--- a/bootstrap/helm/bootstrap-operator/values.yaml.tpl
+++ b/bootstrap/helm/bootstrap-operator/values.yaml.tpl
@@ -1,3 +1,4 @@
+provider: {{ .Provider }}
 operator:
   clusterName: {{ .Cluster }}
   secret: {}

--- a/bootstrap/helm/bootstrap-operator/values.yaml.tpl
+++ b/bootstrap/helm/bootstrap-operator/values.yaml.tpl
@@ -83,6 +83,42 @@ operator:
         name: variables
         key: AWS_SESSION_TOKEN
 {{ end }}
+{{ if eq .Provider "azure" }}
+  clientSecret: {{ .Context.ClientSecret | b64enc | quote }}
+  cloud:
+    azure:
+      version: v1.8.2
+      clusterIdentity: 
+        name: azure-cluster-identity
+        allowedNamespaces: {}
+        clientID: {{ .Context.ClientId }}
+        clientSecret:
+          name: cluster-identity-secret
+          namespace: bootstrap
+        tenantID: {{ .Context.TenantId }}
+        type: ServicePrincipal
+      managedCluster: {}
+      controlPlane:
+        version: v1.26.3
+        resourceGroupName: {{ .Cluster }}
+        location: southcentralus
+        sshPublicKey: ''
+        subscriptionID: {{ .Context.SubscriptionId }}
+        identityRef:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+          kind: AzureClusterIdentity
+          name: azure-cluster-identity
+          namespace: bootstrap
+      machinePools:
+      - name: pool0
+        replicas: 1
+        mode: System
+        sku: Standard_D2s_v3
+      - name: pool1
+        replicas: 2
+        mode: User
+        sku: Standard_D2s_v3
+{{ end }}
 {{ if eq .Provider "google" }}
   secret:
     GCP_B64ENCODED_CREDENTIALS: {{ .Context.Credentials | quote }}

--- a/bootstrap/plural/recipes/azure-cluster-api.yaml
+++ b/bootstrap/plural/recipes/azure-cluster-api.yaml
@@ -6,7 +6,13 @@ private: true
 dependencies: []
 sections:
   - name: bootstrap
-    configuration: []
+    configuration:
+    - name: client_id
+      documentation: Service principal client ID
+      type: STRING
+    - name: client_secret
+      documentation: Service principal password
+      type: STRING
     items:
       - type: TERRAFORM
         name: azure-bootstrap-cluster-api

--- a/bootstrap/plural/recipes/azure-cluster-api.yaml
+++ b/bootstrap/plural/recipes/azure-cluster-api.yaml
@@ -19,6 +19,8 @@ sections:
       - type: HELM
         name: bootstrap
       - type: HELM
+        name: azure-identity
+      - type: HELM
         name: plural-certmanager-webhook
       - type: HELM
         name: bootstrap-operator

--- a/bootstrap/plural/recipes/azure-cluster-api.yaml
+++ b/bootstrap/plural/recipes/azure-cluster-api.yaml
@@ -1,0 +1,18 @@
+name: azure-cluster-api
+description: Creates an AKS cluster and installs the bootstrap chart
+provider: AZURE
+primary: false
+private: true
+dependencies: []
+sections:
+  - name: bootstrap
+    configuration: []
+    items:
+      - type: TERRAFORM
+        name: azure-bootstrap-cluster-api
+      - type: HELM
+        name: bootstrap
+      - type: HELM
+        name: plural-certmanager-webhook
+      - type: HELM
+        name: bootstrap-operator

--- a/bootstrap/plural/recipes/azure-cluster-api.yaml
+++ b/bootstrap/plural/recipes/azure-cluster-api.yaml
@@ -19,8 +19,6 @@ sections:
       - type: HELM
         name: bootstrap
       - type: HELM
-        name: azure-identity
-      - type: HELM
         name: plural-certmanager-webhook
       - type: HELM
         name: bootstrap-operator

--- a/bootstrap/terraform/azure-bootstrap-cluster-api/deps.yaml
+++ b/bootstrap/terraform/azure-bootstrap-cluster-api/deps.yaml
@@ -1,0 +1,11 @@
+apiVersion: plural.sh/v1alpha1
+kind: Dependencies
+metadata:
+  description: Creates an AKS cluster and prepares it for bootstrapping
+  version: 0.1.0
+spec:
+  breaking: true
+  dependencies: []
+  providers:
+  - azure
+

--- a/bootstrap/terraform/azure-bootstrap-cluster-api/main.tf
+++ b/bootstrap/terraform/azure-bootstrap-cluster-api/main.tf
@@ -1,3 +1,4 @@
 data "azurerm_kubernetes_cluster" "cluster" {
   name = var.cluster_name
+  resource_group_name = var.resource_group
 }

--- a/bootstrap/terraform/azure-bootstrap-cluster-api/main.tf
+++ b/bootstrap/terraform/azure-bootstrap-cluster-api/main.tf
@@ -1,0 +1,3 @@
+data "azurerm_kubernetes_cluster" "cluster" {
+  name = var.cluster_name
+}

--- a/bootstrap/terraform/azure-bootstrap-cluster-api/terraform.tfvars
+++ b/bootstrap/terraform/azure-bootstrap-cluster-api/terraform.tfvars
@@ -1,0 +1,1 @@
+cluster_name = {{ .Cluster | quote }}

--- a/bootstrap/terraform/azure-bootstrap-cluster-api/terraform.tfvars
+++ b/bootstrap/terraform/azure-bootstrap-cluster-api/terraform.tfvars
@@ -1,1 +1,2 @@
 cluster_name = {{ .Cluster | quote }}
+resource_group = {{ .Project | quote }}

--- a/bootstrap/terraform/azure-bootstrap-cluster-api/variables.tf
+++ b/bootstrap/terraform/azure-bootstrap-cluster-api/variables.tf
@@ -1,0 +1,4 @@
+variable "cluster_name" {
+  type = string
+  default = "plural"
+}

--- a/bootstrap/terraform/azure-bootstrap-cluster-api/variables.tf
+++ b/bootstrap/terraform/azure-bootstrap-cluster-api/variables.tf
@@ -2,3 +2,7 @@ variable "cluster_name" {
   type = string
   default = "plural"
 }
+
+variable "resource_group" {
+  type = string
+}


### PR DESCRIPTION
## Summary
Adds support for Azure CAPI. See https://github.com/pluralsh/bootstrap-operator/pull/23.

Also pushed some changes to https://github.com/pluralsh/plural-cli/tree/bootstrap to pass context values.

CAPI docs: https://capz.sigs.k8s.io/topics/managedcluster.html

Notes:
- `aadpodidentity.k8s.io` CRDs are registered temporarily as we depend on bootstrap recipe.
- Once CAPI will be the default we can move client ID and secret from recipe to CLI survey.

## Test Plan
```
plural init
plural bundle install bootstrap azure-cluster-api
plural build --cluster-api
plural deploy
```

<img width="1029" alt="Zrzut ekranu 2023-05-18 o 14 06 43" src="https://github.com/pluralsh/plural-artifacts/assets/2823399/c26d587a-34ae-466c-b37b-18b9ef93a6a4">
<img width="1118" alt="Zrzut ekranu 2023-05-18 o 14 10 41" src="https://github.com/pluralsh/plural-artifacts/assets/2823399/c7e45deb-cf4e-4e3c-8c1d-29fd60cffe4c">

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP