### PR TITLE
fix(trace-shield): Allow oauth credentials in basic auth header

### DIFF
--- a/trace-shield/helm/trace-shield/Chart.yaml
+++ b/trace-shield/helm/trace-shield/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: trace-shield
 description: helm chart for trace-shield
 type: application
-version: 0.1.8
+version: 0.1.9
 appVersion: "v0.2.0"
 dependencies:
 - name: kratos

--- a/trace-shield/helm/trace-shield/Chart.yaml
+++ b/trace-shield/helm/trace-shield/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: trace-shield
 description: helm chart for trace-shield
 type: application
-version: 0.1.11
+version: 0.1.12
 appVersion: "v0.2.0"
 dependencies:
 - name: kratos

--- a/trace-shield/helm/trace-shield/Chart.yaml
+++ b/trace-shield/helm/trace-shield/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: trace-shield
 description: helm chart for trace-shield
 type: application
-version: 0.1.9
+version: 0.1.10
 appVersion: "v0.2.0"
 dependencies:
 - name: kratos

--- a/trace-shield/helm/trace-shield/Chart.yaml
+++ b/trace-shield/helm/trace-shield/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: trace-shield
 description: helm chart for trace-shield
 type: application
-version: 0.1.10
+version: 0.1.11
 appVersion: "v0.2.0"
 dependencies:
 - name: kratos

--- a/trace-shield/helm/trace-shield/templates/oathkeeper-rules.yaml
+++ b/trace-shield/helm/trace-shield/templates/oathkeeper-rules.yaml
@@ -18,6 +18,7 @@ data:
         url: https://{{ .Values.config.mimir.publicURL }}/prometheus/api/v1/<status|query|query_range|query_exemplars|series|label|metadata|read|cardinality><.*>
       authenticators:
         - handler: oauth2_introspection
+        - handler: oauth2_client_credentials
       authorizer:
         handler: remote_json
         config:
@@ -42,6 +43,7 @@ data:
         url: https://{{ .Values.config.mimir.publicURL }}</api/v1/push.*|/otlp/v1/metrics.*>
       authenticators:
         - handler: oauth2_introspection
+        - handler: oauth2_client_credentials
       authorizer:
         handler: remote_json
         config:
@@ -66,6 +68,7 @@ data:
         url: https://{{ .Values.config.mimir.publicURL }}</ruler/rule_groups.*|/prometheus/api/v1/rules.*|/prometheus/api/v1/alerts.*|/prometheus/config/v1/rules.*>
       authenticators:
         - handler: oauth2_introspection
+        - handler: oauth2_client_credentials
       authorizer:
         handler: remote_json
         config:
@@ -90,6 +93,7 @@ data:
         url: https://{{ .Values.config.mimir.publicURL }}/prometheus/config/v1/rules/<.*>
       authenticators:
         - handler: oauth2_introspection
+        - handler: oauth2_client_credentials
       authorizer:
         handler: remote_json
         config:
@@ -114,6 +118,7 @@ data:
         url: https://{{ .Values.config.mimir.publicURL }}/prometheus/config/v1/rules/<.*>
       authenticators:
         - handler: oauth2_introspection
+        - handler: oauth2_client_credentials
       authorizer:
         handler: remote_json
         config:
@@ -138,6 +143,7 @@ data:
         url: https://{{ .Values.config.mimir.publicURL }}</multitenant_alertmanager/configs.*|/api/v1/alerts.*> #TODO: add /alertmanager
       authenticators:
         - handler: oauth2_introspection
+        - handler: oauth2_client_credentials
       authorizer:
         handler: remote_json
         config:
@@ -162,6 +168,7 @@ data:
         url: https://{{ .Values.config.mimir.publicURL }}/api/v1/alerts<.*>
       authenticators:
         - handler: oauth2_introspection
+        - handler: oauth2_client_credentials
       authorizer:
         handler: remote_json
         config:
@@ -186,6 +193,7 @@ data:
         url: https://{{ .Values.config.mimir.publicURL }}/api/v1/alerts<.*>
       authenticators:
         - handler: oauth2_introspection
+        - handler: oauth2_client_credentials
       authorizer:
         handler: remote_json
         config:
@@ -215,6 +223,7 @@ data:
         url: https://{{ .Values.config.mimir.publicURL }}/alertmanager<.*> # TODO: does this need to be separate
       authenticators:
         - handler: oauth2_introspection
+        - handler: oauth2_client_credentials
         - handler: cookie_session
       authorizer:
         handler: allow
@@ -235,6 +244,7 @@ data:
         url: https://{{ .Values.config.loki.publicURL }}/loki/api/v1/<query|query_range|label|series|tail><.*>
       authenticators:
         - handler: oauth2_introspection
+        - handler: oauth2_client_credentials
       authorizer:
         handler: remote_json
         config:
@@ -259,6 +269,7 @@ data:
         url: https://{{ .Values.config.loki.publicURL }}/loki/api/v1/push<.*>
       authenticators:
         - handler: oauth2_introspection
+        - handler: oauth2_client_credentials
       authorizer:
         handler: remote_json
         config:
@@ -283,6 +294,7 @@ data:
         url: https://{{ .Values.config.loki.publicURL }}</loki/api/v1/rules|/prometheus/api/v1/rules|/prometheus/config/v1/rules><.*>
       authenticators:
         - handler: oauth2_introspection
+        - handler: oauth2_client_credentials
       authorizer:
         handler: remote_json
         config:
@@ -307,6 +319,7 @@ data:
         url: https://{{ .Values.config.loki.publicURL }}/loki/api/v1/rules<.*>
       authenticators:
         - handler: oauth2_introspection
+        - handler: oauth2_client_credentials
       authorizer:
         handler: remote_json
         config:
@@ -331,6 +344,7 @@ data:
         url: https://{{ .Values.config.loki.publicURL }}/loki/api/v1/rules<.*>
       authenticators:
         - handler: oauth2_introspection
+        - handler: oauth2_client_credentials
       authorizer:
         handler: remote_json
         config:
@@ -357,6 +371,7 @@ data:
         url: https://{{ .Values.config.tempo.publicURL }}/api/<traces|search|v2/search><.*>
       authenticators:
         - handler: oauth2_introspection
+        - handler: oauth2_client_credentials
       authorizer:
         handler: remote_json
         config:
@@ -381,6 +396,7 @@ data:
         url: https://{{ .Values.config.tempo.publicURL }}</otlp/v1/traces|/jaeger/api/traces|/zipkin/spans><.*>
       authenticators:
         - handler: oauth2_introspection
+        - handler: oauth2_client_credentials
       authorizer:
         handler: remote_json
         config:

--- a/trace-shield/helm/trace-shield/templates/oathkeeper-rules.yaml
+++ b/trace-shield/helm/trace-shield/templates/oathkeeper-rules.yaml
@@ -29,7 +29,7 @@ data:
             {
               "subject": {{`"{{ print .Subject }}"`}},
               "requestedPermission": "read_metrics",
-              "isOAuth2Client": {{`{{ eq (print .Subject) (print .Extra.client_id) }}`}}
+              "isOAuth2Client": {{`{{ or (eq (print .Subject) (print .Extra.client_id)) (eq (print .Subject) (regexReplaceAll ":.*" (.MatchContext.Header.Get "Authorization" | trimPrefix "Basic " | b64dec) "")) }}`}}
             }
       mutators:
         - handler: noop
@@ -54,7 +54,7 @@ data:
             {
               "subject": {{`"{{ print .Subject }}"`}},
               "requestedPermission": "write_metrics",
-              "isOAuth2Client": {{`{{ eq (print .Subject) (print .Extra.client_id) }}`}}
+              "isOAuth2Client": {{`{{ or (eq (print .Subject) (print .Extra.client_id)) (eq (print .Subject) (regexReplaceAll ":.*" (.MatchContext.Header.Get "Authorization" | trimPrefix "Basic " | b64dec) "")) }}`}}
             }
       mutators:
         - handler: noop
@@ -79,7 +79,7 @@ data:
             {
               "subject": {{`"{{ print .Subject }}"`}},
               "requestedPermission": "read_metrics_rules",
-              "isOAuth2Client": {{`{{ eq (print .Subject) (print .Extra.client_id) }}`}}
+              "isOAuth2Client": {{`{{ or (eq (print .Subject) (print .Extra.client_id)) (eq (print .Subject) (regexReplaceAll ":.*" (.MatchContext.Header.Get "Authorization" | trimPrefix "Basic " | b64dec) "")) }}`}}
             }
       mutators:
         - handler: noop
@@ -104,7 +104,7 @@ data:
             {
               "subject": {{`"{{ print .Subject }}"`}},
               "requestedPermission": "write_metrics_rules",
-              "isOAuth2Client": {{`{{ eq (print .Subject) (print .Extra.client_id) }}`}}
+              "isOAuth2Client": {{`{{ or (eq (print .Subject) (print .Extra.client_id)) (eq (print .Subject) (regexReplaceAll ":.*" (.MatchContext.Header.Get "Authorization" | trimPrefix "Basic " | b64dec) "")) }}`}}
             }
       mutators:
         - handler: noop
@@ -129,7 +129,7 @@ data:
             {
               "subject": {{`"{{ print .Subject }}"`}},
               "requestedPermission": "delete_metrics_rules",
-              "isOAuth2Client": {{`{{ eq (print .Subject) (print .Extra.client_id) }}`}}
+              "isOAuth2Client": {{`{{ or (eq (print .Subject) (print .Extra.client_id)) (eq (print .Subject) (regexReplaceAll ":.*" (.MatchContext.Header.Get "Authorization" | trimPrefix "Basic " | b64dec) "")) }}`}}
             }
       mutators:
         - handler: noop
@@ -154,7 +154,7 @@ data:
             {
               "subject": {{`"{{ print .Subject }}"`}},
               "requestedPermission": "read_metrics_alerts",
-              "isOAuth2Client": {{`{{ eq (print .Subject) (print .Extra.client_id) }}`}}
+              "isOAuth2Client": {{`{{ or (eq (print .Subject) (print .Extra.client_id)) (eq (print .Subject) (regexReplaceAll ":.*" (.MatchContext.Header.Get "Authorization" | trimPrefix "Basic " | b64dec) "")) }}`}}
             }
       mutators:
         - handler: noop
@@ -179,7 +179,7 @@ data:
             {
               "subject": {{`"{{ print .Subject }}"`}},
               "requestedPermission": "write_metrics_alerts",
-              "isOAuth2Client": {{`{{ eq (print .Subject) (print .Extra.client_id) }}`}}
+              "isOAuth2Client": {{`{{ or (eq (print .Subject) (print .Extra.client_id)) (eq (print .Subject) (regexReplaceAll ":.*" (.MatchContext.Header.Get "Authorization" | trimPrefix "Basic " | b64dec) "")) }}`}}
             }
       mutators:
         - handler: noop
@@ -204,7 +204,7 @@ data:
             {
               "subject": {{`"{{ print .Subject }}"`}},
               "requestedPermission": "delete_metrics_alerts",
-              "isOAuth2Client": {{`{{ eq (print .Subject) (print .Extra.client_id) }}`}}
+              "isOAuth2Client": {{`{{ or (eq (print .Subject) (print .Extra.client_id)) (eq (print .Subject) (regexReplaceAll ":.*" (.MatchContext.Header.Get "Authorization" | trimPrefix "Basic " | b64dec) "")) }}`}}
             }
       mutators:
         - handler: noop
@@ -255,7 +255,7 @@ data:
             {
               "subject": {{`"{{ print .Subject }}"`}},
               "requestedPermission": "read_logs",
-              "isOAuth2Client": {{`{{ eq (print .Subject) (print .Extra.client_id) }}`}}
+              "isOAuth2Client": {{`{{ or (eq (print .Subject) (print .Extra.client_id)) (eq (print .Subject) (regexReplaceAll ":.*" (.MatchContext.Header.Get "Authorization" | trimPrefix "Basic " | b64dec) "")) }}`}}
             }
       mutators:
         - handler: noop
@@ -280,7 +280,7 @@ data:
             {
               "subject": {{`"{{ print .Subject }}"`}},
               "requestedPermission": "write_logs",
-              "isOAuth2Client": {{`{{ eq (print .Subject) (print .Extra.client_id) }}`}}
+              "isOAuth2Client": {{`{{ or (eq (print .Subject) (print .Extra.client_id)) (eq (print .Subject) (regexReplaceAll ":.*" (.MatchContext.Header.Get "Authorization" | trimPrefix "Basic " | b64dec) "")) }}`}}
             }
       mutators:
         - handler: noop
@@ -305,7 +305,7 @@ data:
             {
               "subject": {{`"{{ print .Subject }}"`}},
               "requestedPermission": "read_logs_rules",
-              "isOAuth2Client": {{`{{ eq (print .Subject) (print .Extra.client_id) }}`}}
+              "isOAuth2Client": {{`{{ or (eq (print .Subject) (print .Extra.client_id)) (eq (print .Subject) (regexReplaceAll ":.*" (.MatchContext.Header.Get "Authorization" | trimPrefix "Basic " | b64dec) "")) }}`}}
             }
       mutators:
         - handler: noop
@@ -330,7 +330,7 @@ data:
             {
               "subject": {{`"{{ print .Subject }}"`}},
               "requestedPermission": "write_logs_rules",
-              "isOAuth2Client": {{`{{ eq (print .Subject) (print .Extra.client_id) }}`}}
+              "isOAuth2Client": {{`{{ or (eq (print .Subject) (print .Extra.client_id)) (eq (print .Subject) (regexReplaceAll ":.*" (.MatchContext.Header.Get "Authorization" | trimPrefix "Basic " | b64dec) "")) }}`}}
             }
       mutators:
         - handler: noop
@@ -355,7 +355,7 @@ data:
             {
               "subject": {{`"{{ print .Subject }}"`}},
               "requestedPermission": "delete_logs_rules",
-              "isOAuth2Client": {{`{{ eq (print .Subject) (print .Extra.client_id) }}`}}
+              "isOAuth2Client": {{`{{ or (eq (print .Subject) (print .Extra.client_id)) (eq (print .Subject) (regexReplaceAll ":.*" (.MatchContext.Header.Get "Authorization" | trimPrefix "Basic " | b64dec) "")) }}`}}
             }
       mutators:
         - handler: noop
@@ -382,7 +382,7 @@ data:
             {
               "subject": {{`"{{ print .Subject }}"`}},
               "requestedPermission": "read_traces",
-              "isOAuth2Client": {{`{{ eq (print .Subject) (print .Extra.client_id) }}`}}
+              "isOAuth2Client": {{`{{ or (eq (print .Subject) (print .Extra.client_id)) (eq (print .Subject) (regexReplaceAll ":.*" (.MatchContext.Header.Get "Authorization" | trimPrefix "Basic " | b64dec) "")) }}`}}
             }
       mutators:
         - handler: noop
@@ -407,7 +407,7 @@ data:
             {
               "subject": {{`"{{ print .Subject }}"`}},
               "requestedPermission": "write_traces",
-              "isOAuth2Client": {{`{{ eq (print .Subject) (print .Extra.client_id) }}`}}
+              "isOAuth2Client": {{`{{ or (eq (print .Subject) (print .Extra.client_id)) (eq (print .Subject) (regexReplaceAll ":.*" (.MatchContext.Header.Get "Authorization" | trimPrefix "Basic " | b64dec) "")) }}`}}
             }
       mutators:
         - handler: noop

--- a/trace-shield/helm/trace-shield/values.yaml
+++ b/trace-shield/helm/trace-shield/values.yaml
@@ -454,7 +454,7 @@ oathkeeper:
         oauth2_client_credentials:
           enabled: true
           config:
-            token_url: http://trace-shield-hydra-admin:4444/oauth2/token
+            token_url: http://trace-shield-hydra-public:4444/oauth2/token
 
         noop:
           enabled: true

--- a/trace-shield/helm/trace-shield/values.yaml
+++ b/trace-shield/helm/trace-shield/values.yaml
@@ -450,6 +450,11 @@ oathkeeper:
           config:
             introspection_url: http://trace-shield-hydra-admin:4445/admin/oauth2/introspect
             # scope_strategy: exact
+        
+        oauth2_client_credentials:
+          enabled: true
+          config:
+            token_url: http://trace-shield-hydra-admin:4444/oauth2/token
 
         noop:
           enabled: true


### PR DESCRIPTION
Fixes: https://github.com/pluralsh/trace-shield/issues/34
## Summary
For using and OAuth 2.0 Client as the way to authenticate a Grafana datasource we need to be able to send the Client ID and Secret in the basic auth header.


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP