### PR TITLE
fix(ghost): allow for plural apply

### DIFF
--- a/ghost/helm/ghost/values.yaml
+++ b/ghost/helm/ghost/values.yaml
@@ -12,9 +12,12 @@ mysql:
     repository: dkr.plural.sh/mysql/library/percona
     tag: 5.7.35
   mysqlVersion: "5.7"
+  backupURL: s3://
   backupSchedule: "0 0 0 * * *"
   backupScheduleJobsHistoryLimit: 5
   backupRemoteDeletePolicy: delete # retain|delete
+  backupCredentials:
+    create: "true"
 
 image:
   repository: dkr.plural.sh/ghost/library/ghost


### PR DESCRIPTION
## Summary
Small fixup PR that solves pushing to Plural.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP