### PR TITLE
chore: Prefect-Agent remove API key from helm ref

### DIFF
--- a/prefect-agent/helm/prefect-agent/Chart.yaml
+++ b/prefect-agent/helm/prefect-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prefect-agent
 description: helm chart for prefect-agent
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: v2.10.12
 dependencies:
 - name: prefect-agent

--- a/prefect-agent/helm/prefect-agent/values.yaml.tpl
+++ b/prefect-agent/helm/prefect-agent/values.yaml.tpl
@@ -1,4 +1,3 @@
-apiKey: {{ .Values.apiKey | quote }}
 prefect-agent:
   agent:
     cloudApiConfig:


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you with us! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
- Currently in the `values.yml.tpl` we include the user inputted prefect api key which then is shown in plaintext in the `default-values.yaml` file after a plural build.  The value is ref'd in the secrets.yaml template and should not be needed in the helm template values. 
- Feedback is welcome if the api key needs to be populated here, but if it is expected, we would want to omit it from the git push from the customer side post build as there is an inherent security risk.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [x]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [x]  All major clouds must be supported
    - [x]  Azure
    - [x]  AWS
    - [x]  GCP