### PR TITLE
ci: fix installing commit analyzer

### DIFF
--- a/.github/workflows/matrix-vendor-and-publish.yml
+++ b/.github/workflows/matrix-vendor-and-publish.yml
@@ -232,6 +232,8 @@ jobs:
         node-version: 18.12.1
     - name: Install Semantic Release Plus
       run: npm install -g semantic-release-plus
+    - name: Install @semantic-release/commit-analyzer
+      run: npm install -g @semantic-release/commit-analyzer
     - name: installing plural
       uses: pluralsh/setup-plural@v0.1.5
       with: 


### PR DESCRIPTION
## Summary
After configuring the same commit analyzer we use on other repos the CI failed. This PR should fix it.
