### PR TITLE
feat(mlflow): allow adding tags to s3 bucket

### DIFF
--- a/mlflow/terraform/aws/deps.yaml
+++ b/mlflow/terraform/aws/deps.yaml
@@ -2,7 +2,7 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: mlflow aws setup  
-  version: 0.1.2
+  version: 0.1.3
 spec:
   breaking: true
   dependencies:

--- a/mlflow/terraform/aws/main.tf
+++ b/mlflow/terraform/aws/main.tf
@@ -18,6 +18,7 @@ module "s3_buckets" {
   bucket_names  = [var.mlflow_bucket]
   policy_prefix = var.role_name
   force_destroy = var.force_destroy_bucket
+  bucket_tags   = var.bucket_tags
 }
 
 module "assumable_role_mlflow" {

--- a/mlflow/terraform/aws/variables.tf
+++ b/mlflow/terraform/aws/variables.tf
@@ -27,3 +27,9 @@ variable "force_destroy_bucket" {
   default     = true
   description = "If true, the bucket will be deleted even if it contains objects."
 }
+
+variable "bucket_tags" {
+  type        = map(string)
+  description = "tags to apply to the buckets"
+  default     = {}
+}


### PR DESCRIPTION
## Summary
This PR allows users to add tags to the MLFlow S3 bucket easily.


## Test Plan
Local linking


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP