### PR TITLE
fix(trace-shield): allow auth header

### DIFF
--- a/trace-shield/helm/trace-shield/Chart.yaml
+++ b/trace-shield/helm/trace-shield/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: trace-shield
 description: helm chart for trace-shield
 type: application
-version: 0.1.13
-appVersion: "v0.6.0"
+version: 0.1.14
+appVersion: "v0.6.1"
 dependencies:
 - name: kratos
   version: 0.32.0

--- a/trace-shield/helm/trace-shield/values.yaml
+++ b/trace-shield/helm/trace-shield/values.yaml
@@ -5,7 +5,7 @@ backend:
     repository: ghcr.io/pluralsh/trace-shield/backend
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 0.6.0
+    tag: 0.6.1
 
   imagePullSecrets: []
   nameOverride: ""
@@ -71,7 +71,7 @@ frontend:
     repository: ghcr.io/pluralsh/trace-shield/frontend
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 0.6.0
+    tag: 0.6.1
 
   imagePullSecrets: []
   nameOverride: ""


### PR DESCRIPTION
## Summary
Bumps trace shield with a fix for using an auth header to access the API.