### PR TITLE
feat: Create Azure MSI in Terraform

### DIFF
--- a/bootstrap/terraform/azure-bootstrap/deps.yaml
+++ b/bootstrap/terraform/azure-bootstrap/deps.yaml
@@ -2,7 +2,7 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: Creates a AKS cluster and prepares it for bootstrapping 
-  version: 0.1.27
+  version: 0.1.28
 spec:
   dependencies: []
   providers:
@@ -16,6 +16,7 @@ spec:
     network: network
     kubelet_msi_id: kubelet_msi_id
     node_resource_group: node_resource_group
+    plural_msi: plural_msi
   provider_wirings:
     cluster: module.azure-bootstrap.cluster
   provider_vsn: "0.1.2"

--- a/bootstrap/terraform/azure-bootstrap/main.tf
+++ b/bootstrap/terraform/azure-bootstrap/main.tf
@@ -2,6 +2,12 @@ data "azurerm_resource_group" "group" {
   name = var.resource_group
 }
 
+resource "azurerm_user_assigned_identity" "msi" {
+  name                = "plural"
+  resource_group_name = data.azurerm_resource_group.group.name
+  location            = data.azurerm_resource_group.group.location
+}
+
 module "network" {
   source              = "github.com/pluralsh/terraform-azurerm-network?ref=plural"
 

--- a/bootstrap/terraform/azure-bootstrap/outputs.tf
+++ b/bootstrap/terraform/azure-bootstrap/outputs.tf
@@ -3,6 +3,10 @@ output "cluster" {
   sensitive = true
 }
 
+output "plural_msi" {
+  value = azurerm_user_assigned_identity.msi
+}
+
 output "kubelet_msi_id" {
   value = module.aks.kubelet_identity[0].client_id
 }


### PR DESCRIPTION
## Summary
Azure MSI will be used when clusters will be migrated to CAPZ. Adding it now to simplify migration in the future.

## Test Plan
It was tested manually. See https://github.com/pluralsh/plural-artifacts/pull/741/commits/9ba6896018b400c312ba840c47a9c904d17c8f3e.

## Checklist
- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP