### PR TITLE
feat: Add docs for mlflow basic auth

### DIFF
--- a/mlflow/plural/docs/basic-auth.md
+++ b/mlflow/plural/docs/basic-auth.md
@@ -1,0 +1,38 @@
+## Configuring Basic Auth
+
+Mlflows's api and web interface is not authenticated by default.  We provide an oauth proxy by default to grant some security to your mlflow install, but in order to integrate with tools like airflow, you'll likely want a means to authenticate with static creds.  That's where basic auth can be very useful. The process is fortunately simple.
+
+### modify context.yaml
+
+in the `context.yaml` file at the root of your repo, simply add:
+
+```yaml
+configuration:
+  mlflow:
+    users:
+      <name>: <password>
+      <name2>: <password2>
+```
+you can use `plural crypto random` to generate a high-entropy password if that is helpful as well.
+
+### redeploy
+
+Simply run `plural build --only mlflow && plural deploy --commit "enabling basic auth"` to wire in the credentials to our oauth proxy.  Occasionally you need to restart the web pods to get it to take, you can find them with:
+
+```sh
+kubectl get pods -n mlflow
+```
+
+the pods will look something like `mlflow-66ffb5d876-fq8ls` (random suffixes will vary).
+
+then delete them (allowing k8s to restart) with:
+
+```sh
+kubectl delete pod <name> -n mlflow
+```
+
+### Access
+
+From there you can either use a standard basic auth header to authenticate to your mlflow instance, or set the url as: `https://{user}:{password}@{your-mlflow-hostname}` in whatever code needs to call the mlflow api.
+
+The mlflow python client also supports handling basic auth via a few custom env vars documented here: https://www.mlflow.org/docs/latest/tracking.html#logging-to-a-tracking-server

--- a/mlflow/repository.yaml
+++ b/mlflow/repository.yaml
@@ -3,6 +3,7 @@ description: An open-source platform that streamlines machine learning developme
 category: DEVOPS
 icon: plural/icons/mlflow.png
 notes: plural/notes.tpl
+docs: plural/docs
 homepage: https://mlflow.org/
 gitUrl: https://github.com/mlflow/mlflow
 oauthSettings:


### PR DESCRIPTION
## Summary

This is basically copypasta from the airbyte docs since they're effectively the same.

## Test Plan
n/a


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP