### PR TITLE
Upgrade metabase to v0.46.6 and add path image to vendor list

### DIFF
--- a/metabase/helm/metabase/Chart.yaml
+++ b/metabase/helm/metabase/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: metabase
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.12
-appVersion: "0.46.5"
+version: 0.1.13
+appVersion: "0.46.6"
 dependencies:
 - name: postgres
   version: 0.1.16

--- a/metabase/helm/metabase/values.yaml
+++ b/metabase/helm/metabase/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: dkr.plural.sh/metabase/metabase/metabase
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: v0.46.5
+  tag: v0.46.6
 
 listen:
   host: "0.0.0.0"

--- a/metabase/vendor_images.yaml
+++ b/metabase/vendor_images.yaml
@@ -1,3 +1,6 @@
 docker.io:
   images-by-tag-regex:
     metabase/metabase: ^v?[0-9]+\.[0-9]+?\.[0-9]+$
+  images:
+    metabase/metabase:
+    - v0.46.6.1


### PR DESCRIPTION
## Summary

This will help handle a security vuln for metabase we need to path.

Fixes #781

## Test Plan
link


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP