### PR TITLE
feat: Support mlflow object versioning

### DIFF
--- a/mlflow/plural/docs/bucket-versioning.md
+++ b/mlflow/plural/docs/bucket-versioning.md
@@ -1,0 +1,13 @@
+## Enable Bucket Versioning
+
+In case you want to enable s3 object versioning, this is supported via a small terraform configuration.  Go to `mlflow/terraform/main.tf` and within the manual section of the `aws` module, add:
+
+```tf
+module "aws" {
+  ## BEGIN MANUAL SECTION <- be sure to put it w/in these
+  enable_versioning = true
+  ## END MANUAL SECTION
+}
+```
+
+Then run a quick `plural deploy --commit "enable mlflow s3 versioning"` and you'll be set.

--- a/mlflow/terraform/aws/deps.yaml
+++ b/mlflow/terraform/aws/deps.yaml
@@ -2,9 +2,8 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: mlflow aws setup  
-  version: 0.1.4
+  version: 0.1.5
 spec:
-  breaking: true
   dependencies:
   - name: aws-bootstrap
     repo: bootstrap

--- a/mlflow/terraform/aws/main.tf
+++ b/mlflow/terraform/aws/main.tf
@@ -14,11 +14,12 @@ data "aws_eks_cluster" "cluster" {
 }
 
 module "s3_buckets" {
-  source        = "github.com/pluralsh/module-library//terraform/s3-buckets?ref=bucket-protection"
-  bucket_names  = [var.mlflow_bucket]
-  policy_prefix = var.role_name
-  force_destroy = var.force_destroy_bucket
-  bucket_tags   = var.bucket_tags
+  source            = "github.com/pluralsh/module-library//terraform/s3-buckets?ref=bucket-protection"
+  bucket_names      = [var.mlflow_bucket]
+  policy_prefix     = var.role_name
+  force_destroy     = var.force_destroy_bucket
+  bucket_tags       = var.bucket_tags
+  enable_versioning = var.enable_versioning
 }
 
 module "assumable_role_mlflow" {

--- a/mlflow/terraform/aws/variables.tf
+++ b/mlflow/terraform/aws/variables.tf
@@ -33,3 +33,9 @@ variable "bucket_tags" {
   description = "tags to apply to the buckets"
   default     = {}
 }
+
+variable "enable_versioning" {
+  type = bool
+  description = "enable s3 object versioning"
+  default = false
+}


### PR DESCRIPTION
## Summary

The underlying terraform module supports this, but we didn't add the plumbing to be able to wire it in.

## Test Plan
link


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP