### PR TITLE
Double posthog plugin mem limit

### DIFF
--- a/posthog/helm/posthog/Chart.yaml
+++ b/posthog/helm/posthog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: posthog
 description: helm chart for posthog
 type: application
-version: 0.1.10
+version: 0.1.11
 appVersion: "1.43.1"
 dependencies:
 - name: posthog

--- a/posthog/helm/posthog/values.yaml
+++ b/posthog/helm/posthog/values.yaml
@@ -12,7 +12,7 @@ posthog:
         cpu: 20m
         memory: 500Mi
       limits:
-        memory: 1Gi
+        memory: 2Gi
     livenessProbe:
       failureThreshold: 10
     topologySpreadConstraints:


### PR DESCRIPTION
## Summary

Apparently the plugin server will sometimes perpetually OOM on boot, this should help

## Test Plan
n/a


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP