### PR TITLE
Add postgres user for s3 backup/restore

### DIFF
--- a/postgres/terraform/aws/deps.yaml
+++ b/postgres/terraform/aws/deps.yaml
@@ -2,7 +2,7 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: postgres aws setup
-  version: 0.1.3
+  version: 0.1.4
 spec:
   dependencies:
   - name: aws-bootstrap

--- a/postgres/terraform/aws/iam.tf
+++ b/postgres/terraform/aws/iam.tf
@@ -1,0 +1,29 @@
+resource "aws_iam_user" "postgres" {
+  name = "plural-${var.cluster_name}-postgres"
+}
+
+resource "aws_iam_user_policy" "postgres-user-policy" {
+  name   = "plural-${var.cluster_name}-postgres-user"
+  user   = aws_iam_user.postgres.name
+  policy = data.aws_iam_policy_document.postgres.json
+}
+
+resource "aws_iam_access_key" "postgres" {
+  user = aws_iam_user.postgres.name
+}
+
+resource "kubernetes_secret" "example" {
+  metadata {
+    name = "postgres-user-auth"
+    namespace = var.namespace
+  }
+
+  data = {
+    ACCESS_KEY_ID = aws_iam_access_key.postgres.id
+    SECRET_ACCESS_KEY = aws_iam_access_key.postgres.secret
+  }
+
+  depends_on = [
+    kubernetes_namespace.postgres
+  ]
+}


### PR DESCRIPTION
## Summary

There seems to be a bug in the wal-g restore process in the postgres operator that prevents it from authing with IRSA. For now just add a fixed keypair to use in backups which will be synced into the console's new pg management backend.

## Test Plan
link


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP