### PR TITLE
feat: Add basic auth to app info

### DIFF
--- a/airbyte/plural/notes.tpl
+++ b/airbyte/plural/notes.tpl
@@ -5,14 +5,24 @@ It looks like you've enabled OIDC!  Login will be managed by plural from now on,
 feel free to add your teammembers in the OIDC configuration page in the plural UI.
 {{ else }}
 You did not enable OIDC for your airbyte install.  It will not be accessible publicly since airbyte OSS 
-does not have native authentication support.  If you want, you can enable oidc be running the bundle install command,
+does not have native authentication support.  If you want, you can enable oidc by running the bundle install command,
 eg:
 
 ```
-plural bundle install airbyte airbyte-aws
+plural bundle install airbyte
 plural build --only airbyte
 plural deploy --commit "enable airbyte oidc"
 ```
 
 (be sure to enable oidc at the end)
 {{ end }}
+
+{{- if .Values.users }}
+It looks like you've also configured basic auth for your airbyte instance, the credentials are as followed:
+
+{{- range $user, $pwd := .Values.users }}
+User: {{ $user }}
+Password: {{ $pwd }}
+{{- end }}
+
+{{- end}}

--- a/mlflow/plural/notes.tpl
+++ b/mlflow/plural/notes.tpl
@@ -1,3 +1,14 @@
  You can view your installation at https://{{ .Values.hostname }}
 
  See https://github.com/pluralsh/mlflow-on-k8s-example for example usage.
+
+
+{{- if .Values.users }}
+It looks like you've also configured basic auth for your mlflow instance, the credentials are as followed:
+
+{{- range $user, $pwd := .Values.users }}
+User: {{ $user }}
+Password: {{ $pwd }}
+{{- end }}
+
+{{- end}}

--- a/prefect/plural/notes.tpl
+++ b/prefect/plural/notes.tpl
@@ -1,1 +1,28 @@
 Use `plural watch prefect` to track the status of your application
+
+{{ if .OIDC }}
+It looks like you've enabled OIDC!  Login will be managed by plural from now on,
+feel free to add your teammembers in the OIDC configuration page in the plural UI.
+{{ else }}
+You did not enable OIDC for your prefect install.  It will not be accessible publicly since prefect OSS 
+does not have native authentication support.  If you want, you can enable oidc by running the bundle install command,
+eg:
+
+```
+plural bundle install prefect
+plural build --only prefect
+plural deploy --commit "enable prefect oidc"
+```
+
+(be sure to enable oidc at the end)
+{{ end }}
+
+{{- if .Values.users }}
+It looks like you've also configured basic auth for your prefect instance, the credentials are as followed:
+
+{{- range $user, $pwd := .Values.users }}
+User: {{ $user }}
+Password: {{ $pwd }}
+{{- end }}
+
+{{- end}}


### PR DESCRIPTION
## Summary
This will help with discovery for basic auth creds for various apps


## Test Plan
n/a


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP