### PR TITLE
fix(airbyte): fix workload identity

### DIFF
--- a/airbyte/helm/airbyte/Chart.yaml
+++ b/airbyte/helm/airbyte/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: airbyte
 description: Unified data integration platform
 type: application
-version: 0.4.23
+version: 0.4.24
 appVersion: 0.50.8
 dependencies:
 - name: airbyte

--- a/airbyte/helm/airbyte/values.yaml.tpl
+++ b/airbyte/helm/airbyte/values.yaml.tpl
@@ -118,3 +118,8 @@ airbyte:
       rootUser: {{ importValue "Terraform" "access_key_id" }}
       rootPassword: {{ importValue "Terraform" "secret_access_key" }}
   {{- end }}
+  serviceAccount:
+    {{ if $isGcp }}
+    annotations:
+      iam.gke.io/gcp-service-account: {{ importValue "Terraform" "gcp_sa_email" }}
+    {{ end }}

--- a/airbyte/terraform/gcp/deps.yaml
+++ b/airbyte/terraform/gcp/deps.yaml
@@ -15,3 +15,4 @@ spec:
     access_key_id: access_key_id
     secret_access_key: secret_access_key
     credentials_json: credentials_json
+    gcp_sa_email: gcp_sa_email

--- a/airbyte/terraform/gcp/deps.yaml
+++ b/airbyte/terraform/gcp/deps.yaml
@@ -2,7 +2,7 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: airbyte gcp setup 
-  version: 0.1.4
+  version: 0.1.5
 spec:
   dependencies:
   - name: gcp-bootstrap

--- a/airbyte/terraform/gcp/main.tf
+++ b/airbyte/terraform/gcp/main.tf
@@ -64,29 +64,18 @@ resource "kubernetes_secret" "google-application-credentials" {
 
 module "airbyte-workload-identity" {
   source              = "terraform-google-modules/kubernetes-engine/google//modules/workload-identity"
-  name                = "${var.cluster_name}-airbyte-wi"
+  name                = "${var.cluster_name}-airbyte"
   namespace           = var.namespace
   project_id          = var.project_id
   use_existing_k8s_sa = true
   annotate_k8s_sa     = false
-  k8s_sa_name         = "default"
+  k8s_sa_name         = "airbyte-admin"
   roles               = var.roles
+  gcp_sa_name         = google_service_account.airbyte.name
+  use_existing_gcp_sa = true
 
   depends_on = [
-    kubernetes_namespace.airbyte
-  ]
-}
-
-resource "kubernetes_default_service_account" "default" {
-  metadata {
-    name      = "default"
-    namespace = var.namespace
-    annotations = {
-      "iam.gke.io/gcp-service-account" = module.airbyte-workload-identity.gcp_service_account_email
-    }
-  }
-
-  depends_on = [
-    kubernetes_namespace.airbyte
+    kubernetes_namespace.airbyte,
+    google_service_account.airbyte
   ]
 }

--- a/airbyte/terraform/gcp/outputs.tf
+++ b/airbyte/terraform/gcp/outputs.tf
@@ -9,3 +9,7 @@ output "secret_access_key" {
 output "credentials_json" {
   value = google_service_account_key.airbyte_key.private_key
 }
+
+output "gcp_sa_email" {
+  value = google_service_account.airbyte.email
+}


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you with us! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
Now that airbyte uses the configured service account (and no more default) when spawning pods, we need to configure workload identity properly

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Local link + deploy
Tested with a BigQuery destination (with ADC and roles configured on gcp sa)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP