### PR TITLE
feat(bootstrap): upgrade AWS EKS to K8s 1.24 + NAT improvements

### DIFF
--- a/bootstrap/terraform/aws-bootstrap/deps.yaml
+++ b/bootstrap/terraform/aws-bootstrap/deps.yaml
@@ -1,8 +1,8 @@
 apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
-  description: Creates an EKS cluster and prepares it for bootstrapping 
-  version: 0.1.51
+  description: Creates an EKS cluster and prepares it for bootstrapping
+  version: 0.1.52
 spec:
   breaking: true
   dependencies: []

--- a/bootstrap/terraform/aws-bootstrap/main.tf
+++ b/bootstrap/terraform/aws-bootstrap/main.tf
@@ -17,7 +17,7 @@ module "vpc" {
   database_subnets = var.database_subnets
 
   enable_nat_gateway = true
-  single_nat_gateway = true
+  single_nat_gateway = false
 
   public_subnet_tags = {
     "kubernetes.io/cluster/${var.cluster_name}" = "shared"

--- a/bootstrap/terraform/aws-bootstrap/s3-vpc-endpoint.tf
+++ b/bootstrap/terraform/aws-bootstrap/s3-vpc-endpoint.tf
@@ -1,6 +1,6 @@
 data "aws_route_table" "worker_private_subnets_route_table" {
-  count     = var.enable_vpc_s3_endpoint && length(local.worker_private_subnet_ids) > 0 ? 1 : 0
-  subnet_id = local.worker_private_subnet_ids[0]
+  count     = var.enable_vpc_s3_endpoint && length(local.worker_private_subnet_ids) > 0 ? length(local.worker_private_subnet_ids) : 0
+  subnet_id = local.worker_private_subnet_ids[count.index]
 }
 
 resource "aws_vpc_endpoint" "s3" {
@@ -8,5 +8,5 @@ resource "aws_vpc_endpoint" "s3" {
   vpc_id          = local.vpc_id
   service_name    = "com.amazonaws.${var.aws_region}.s3"
   auto_accept     = true
-  route_table_ids = [data.aws_route_table.worker_private_subnets_route_table[0].id]
+  route_table_ids = data.aws_route_table.worker_private_subnets_route_table[*].id
 }

--- a/bootstrap/terraform/aws-bootstrap/variables.tf
+++ b/bootstrap/terraform/aws-bootstrap/variables.tf
@@ -28,7 +28,7 @@ variable "cluster_log_retention_in_days" {
 variable "kubernetes_version" {
   type = string
   description = "Kubernetes version to use for the cluster"
-  default = "1.23"
+  default = "1.24"
 }
 
 variable "vpc_cni_addon_version" {
@@ -225,7 +225,7 @@ variable "node_groups_defaults" {
 
     instance_types = ["t3.large", "t3a.large"]
     disk_size = 50
-    ami_release_version = "1.23.16-20230217"
+    ami_release_version = "1.24.15-20230816"
     force_update_version = true
     ami_type = "AL2_x86_64"
     k8s_labels = {}


### PR DESCRIPTION
## Summary
This PR upgrade the Kubernetes version for our AWS EKS deployments to 1.24 since the EOL is coming up. It also takes the opportunity of this breaking change to improve the VPC and subnet configuration a bit. While working on our migration to Cluster API an issue was observed where the migration got stuck as the CAPA pod lost communication to AWS while it was shuffling around the NAT gateways and route tables of the subnets the workers are deployed in. The reason to have a NAT gateway in each subnet is to avoid cross AZ ingress/egress charges for any data going to/from the public internet. Applying this change to the networking setup as part of the Terraform should help ensure the migration to CAPI is more smooth.


## Test Plan
Local linking

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP