### PR TITLE
fix(ray): upgrade eks node groups to 1.23

### DIFF
--- a/ray/terraform/aws/deps.yaml
+++ b/ray/terraform/aws/deps.yaml
@@ -2,12 +2,12 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: ray aws setup
-  version: 0.1.3
+  version: 0.1.4
 spec:
   dependencies:
   - name: aws-bootstrap
     repo: bootstrap
     type: terraform
-    version: '>= 0.1.47'
+    version: '>= 0.1.51'
   providers:
   - aws

--- a/ray/terraform/aws/variables.tf
+++ b/ray/terraform/aws/variables.tf
@@ -32,7 +32,7 @@ variable "node_groups_defaults" {
 
     instance_types       = ["t3.large", "t3a.large"]
     disk_size            = 50
-    ami_release_version  = "1.22.15-20221222"
+    ami_release_version  = "1.23.16-20230217"
     force_update_version = true
     ami_type             = "AL2_x86_64"
     k8s_labels           = {}


### PR DESCRIPTION
## Summary
This PR upgrade the node groups used by Ray to Kubernetes 1.23.