### PR TITLE
feat(bootstrap): bump aws addon versions

### DIFF
--- a/bootstrap/terraform/aws-bootstrap/deps.yaml
+++ b/bootstrap/terraform/aws-bootstrap/deps.yaml
@@ -2,9 +2,9 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: Creates an EKS cluster and prepares it for bootstrapping
-  version: 0.1.52
+  version: 0.1.53
 spec:
-  breaking: true
+  breaking: false
   dependencies: []
   providers:
   - aws

--- a/bootstrap/terraform/aws-bootstrap/variables.tf
+++ b/bootstrap/terraform/aws-bootstrap/variables.tf
@@ -33,19 +33,19 @@ variable "kubernetes_version" {
 
 variable "vpc_cni_addon_version" {
   type = string
-  default = "v1.12.5-eksbuild.1"
+  default = "v1.13.4-eksbuild.1"
   description = "The version of the VPC-CNI addon to use"
 }
 
 variable "core_dns_addon_version" {
   type = string
-  default = "v1.8.7-eksbuild.4"
+  default = "v1.9.3-eksbuild.6"
   description = "The version of the CoreDNS addon to use"
 }
 
 variable "kube_proxy_addon_version" {
   type = string
-  default = "v1.23.15-eksbuild.1"
+  default = "v1.24.15-eksbuild.2"
   description = "The version of the kube-proxy addon to use"
 }
 


### PR DESCRIPTION
## Summary
This PR bumps the addons for AWS clusters. The VPC CNI addon needs to be bumped to `1.13` before it can be bumped to the latest `1.14` version.