### PR TITLE
fix: allow both google and gcp provider

### DIFF
--- a/airflow/helm/airflow/Chart.yaml
+++ b/airflow/helm/airflow/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: airflow
 description: A Helm chart for airflow deployable on plural
 type: application
-version: 0.3.38
+version: 0.3.39
 appVersion: "2.6.3"
 sources:
   - https://github.com/pluralsh/plural-artifacts/airflow/helm/airflow

--- a/airflow/helm/airflow/values.yaml.tpl
+++ b/airflow/helm/airflow/values.yaml.tpl
@@ -1,3 +1,4 @@
+{{ $isGcp := or (eq .Provider "google") (eq .Provider "gcp") }}
 global:
   application:
     links:
@@ -80,13 +81,13 @@ airflow:
               else:
                   return {}
           oauth_user_info = _get_oauth_user_info
-        
+
         SECURITY_MANAGER_CLASS = PluralSecurityManager
 
         SQLALCHEMY_DATABASE_URI = conf.get('core', 'SQL_ALCHEMY_CONN')
-        
+
         AUTH_TYPE = AUTH_OAUTH
-        
+
         # registration configs
         AUTH_USER_REGISTRATION = True  # allow users who are not already in the FAB DB
         AUTH_USER_REGISTRATION_ROLE = "Admin"  # this role will be given in addition to any AUTH_ROLES_MAPPING
@@ -112,7 +113,7 @@ airflow:
                 }
             }
         ]
-        
+
         # force users to re-auth after 30min of inactivity (to keep roles in sync)
         PERMANENT_SESSION_LIFETIME = 1800
   {{ end }}
@@ -129,7 +130,7 @@ airflow:
   airflow:
     config:
       AIRFLOW__WEBSERVER__BASE_URL: https://{{ $hostname }}
-    {{ if eq .Provider "google" }}
+    {{ if $isGcp }}
       AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER: "gs://{{ .Values.airflowBucket }}/airflow/logs"
     {{ end }}
     {{ if or (eq .Provider "aws") (eq .Provider "azure") (eq .Provider "kind") }}
@@ -138,8 +139,8 @@ airflow:
     {{ if or (eq .Provider "azure") (eq .Provider "kind") }}
       AIRFLOW__LOGGING__REMOTE_LOG_CONN_ID: minio
     {{ end }}
-  
-    {{ if eq .Provider "google" }}
+
+    {{ if $isGcp }}
     connections:
     ## see docs: https://airflow.apache.org/docs/apache-airflow-providers-google/stable/connections/gcp.html
     - id: plural
@@ -180,7 +181,7 @@ airflow:
     {{ end }}
 
   serviceAccount:
-  {{ if eq .Provider "google" }}
+  {{ if $isGcp }}
     create: false
   {{ end }}
     annotations:

--- a/argo-workflows/helm/argo-workflows/Chart.yaml
+++ b/argo-workflows/helm/argo-workflows/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-workflows
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.28
+version: 0.1.29
 appVersion: "v3.2.9"
 dependencies:
 - name: argo-workflows

--- a/argo-workflows/helm/argo-workflows/values.yaml.tpl
+++ b/argo-workflows/helm/argo-workflows/values.yaml.tpl
@@ -1,3 +1,4 @@
+{{ $isGcp := or (eq .Provider "google") (eq .Provider "gcp") }}
 {{- if .OIDC }}
 oidcSecret:
   clientID: {{ .OIDC.ClientId }}
@@ -79,7 +80,7 @@ artifactRepository:
       name: minio-secret
       key: secret-key
   {{ end }}
-  {{ if eq .Provider "google" }}
+  {{ if $isGcp }}
   gcs:
     bucket: {{ .Values.workflowBucket | quote }}
   {{ end }}
@@ -99,7 +100,7 @@ serviceAccount:
   annotations:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Project }}:role/{{ .Cluster }}-argo-workflows"
   {{- end }}
-  {{ if eq .Provider "google" }}
+  {{ if $isGcp }}
   annotations:
     iam.gke.io/gcp-service-account: {{ importValue "Terraform" "service_account_email" }}
   {{ end }}

--- a/bootstrap/helm/bootstrap/Chart.yaml
+++ b/bootstrap/helm/bootstrap/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   email: mguarino46@gmail.com
 - name: David van der Spek
   email: david@plural.sh
-version: 0.8.71
+version: 0.8.72
 dependencies:
 - name: external-dns
   version: 6.14.1

--- a/bootstrap/helm/bootstrap/templates/defaultstorageclass.yaml
+++ b/bootstrap/helm/bootstrap/templates/defaultstorageclass.yaml
@@ -6,7 +6,7 @@ metadata:
   labels: {{ include "bootstrap.labels" . | nindent 4 }}
 spec:
   name: ebs-csi
-{{- else if eq .Values.provider "google" }}
+{{- else if or (eq .Values.provider "google") (eq .Values.provider "gcp") }}
 apiVersion: platform.plural.sh/v1alpha1
 kind: DefaultStorageClass
 metadata:

--- a/bootstrap/helm/bootstrap/templates/snapshot.yaml
+++ b/bootstrap/helm/bootstrap/templates/snapshot.yaml
@@ -7,7 +7,7 @@ metadata:
     snapshot.storage.kubernetes.io/is-default-class: "true"
 driver: ebs.csi.aws.com
 deletionPolicy: Delete
-{{- else if eq .Values.provider "google" }}
+{{- else if or (eq .Values.provider "google") (eq .Values.provider "gcp") }}
 apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:

--- a/bootstrap/helm/bootstrap/values.yaml.tpl
+++ b/bootstrap/helm/bootstrap/values.yaml.tpl
@@ -1,3 +1,4 @@
+{{ $isGcp := or (eq .Provider "google") (eq .Provider "gcp") }}
 {{ $pluraldns := .Network.PluralDns }}
 {{ $providerArgs := dict "provider" .Provider "cluster" .Cluster }}
 {{ if eq .Provider "google" }}
@@ -10,6 +11,8 @@ external-dns:
   extraArgs:
     plural-cluster: {{ $providerArgs.cluster }}
     plural-provider: {{ $providerArgs.provider }}
+  {{ else if $isGcp }}
+  provider: google
   {{ else }}
   provider: {{ .Provider }}
   {{ end }}
@@ -21,7 +24,7 @@ external-dns:
   rbac:
     create: true
   serviceAccount:
-{{ if eq .Provider "google" }}
+{{ if $isGcp }}
     create: false
 {{ end }}
     name: {{ default "external-dns" .Values.externaldns_service_account }}
@@ -31,7 +34,7 @@ external-dns:
     {{- end }}
   domainFilters:
   - {{ .Network.Subdomain }}
-  {{- if eq .Provider "google" }}
+  {{- if $isGcp }}
   google:
     project: {{ .Project }}
   {{- end }}
@@ -85,8 +88,8 @@ regcreds:
 provider: {{ .Provider }}
 ownerEmail: {{ .Config.Email }}
 
-{{ if eq (default "google" .Provider) "aws" }}
-{{- if not .Values.disable_cluster_autoscaler }} 
+{{ if eq .Provider "aws" }}
+{{- if not .Values.disable_cluster_autoscaler }}
 cluster-autoscaler:
   enabled: true
   awsRegion: {{ .Region }}
@@ -179,7 +182,7 @@ dnsSolver:
     environment: AzurePublicCloud
 {{ end }}
 
-{{ if eq .Provider "google" }}
+{{ if $isGcp }}
 cert-manager:
   serviceAccount:
     create: false

--- a/chatwoot/helm/chatwoot/Chart.yaml
+++ b/chatwoot/helm/chatwoot/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chatwoot
 description: Open-source customer engagement suite, an alternative to Intercom, Zendesk, Salesforce Service Cloud etc.
 type: application
-version: 0.1.7
+version: 0.1.8
 appVersion: v2.15.0
 dependencies:
 - name: chatwoot

--- a/chatwoot/helm/chatwoot/values.yaml.tpl
+++ b/chatwoot/helm/chatwoot/values.yaml.tpl
@@ -1,3 +1,4 @@
+{{ $isGcp := or (eq .Provider "google") (eq .Provider "gcp") }}
 {{- $redisNamespace := namespace "redis" }}
 {{ $redisValues := .Applications.HelmValues "redis" }}
 global:
@@ -8,7 +9,7 @@ global:
 
 chatwoot:
   serviceAccount:
-    {{- if eq .Provider "google" }}
+    {{- if $isGcp }}
     create: false
     {{- end }}
     name: chatwoot
@@ -41,7 +42,7 @@ chatwoot:
     ACTIVE_STORAGE_SERVICE: amazon
     S3_BUCKET_NAME: {{ .Values.chatwootBucket }}
     AWS_REGION: {{ .Region }}
-    {{- else if eq .Provider "google" }}
+    {{- else if $isGcp }}
     ACTIVE_STORAGE_SERVICE: google
     GCS_PROJECT: {{ .Project }}
     GCS_BUCKET: {{ .Values.chatwootBucket }}

--- a/gitlab/helm/gitlab/Chart.yaml
+++ b/gitlab/helm/gitlab/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: gitlab
 description: A Helm chart for gitlab on plural
 type: application
-version: 0.5.12
+version: 0.5.13
 appVersion: 15.2.2
 dependencies:
 - name: gitlab

--- a/gitlab/helm/gitlab/values.yaml.tpl
+++ b/gitlab/helm/gitlab/values.yaml.tpl
@@ -1,3 +1,4 @@
+{{ $isGcp := or (eq .Provider "google") (eq .Provider "gcp") }}
 global:
   application:
     links:
@@ -51,13 +52,13 @@ global:
         secret: objectstore-connection
         key: connection
   serviceAccount:
-    {{ if eq .Provider "google" }}
+    {{ if $isGcp }}
     create: false
     {{ end }}
     annotations:
       eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Project }}:role/{{ .Cluster }}-gitlab"
 
-{{ if eq .Provider "google" }}
+{{ if $isGcp }}
 serviceAccount:
   create: false
   name: gitlab-runner
@@ -97,7 +98,7 @@ gitlab:
         s3BucketName: {{ .Values.runnerCacheBucket }}
         s3BucketLocation: {{ .Region }}
       {{ end }}
-      {{ if eq .Provider "google" }}
+      {{ if $isGcp }}
         cacheType: gcs
         gcsBucketName: {{ .Values.runnerCacheBucket }}
       {{ end }}
@@ -109,7 +110,7 @@ gitlab:
       {{ end }}
 
 railsConnection:
-{{ if eq .Provider "google" }}
+{{ if $isGcp }}
   provider: Google
   google_project: {{ .Project }}
   google_application_default: true
@@ -134,7 +135,7 @@ registryConnection:
     region: {{ .Region }}
     v4auth: true
 {{ end }}
-{{ if eq .Provider "google" }}
+{{ if $isGcp }}
   gcs:
     bucket: {{ .Values.registryBucket }}
 {{ end }}

--- a/growthbook/helm/growthbook/Chart.yaml
+++ b/growthbook/helm/growthbook/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: growthbook
 description: growthbook helm setup
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: "v1.9.0"

--- a/growthbook/helm/growthbook/values.yaml.tpl
+++ b/growthbook/helm/growthbook/values.yaml.tpl
@@ -1,3 +1,4 @@
+{{ $isGcp := or (eq .Provider "google") (eq .Provider "gcp") }}
 global:
   application:
     links:
@@ -8,8 +9,9 @@ global:
 
 serviceAccount:
   annotations:
+    {{ if eq .Provider "aws" }}
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Project }}:role/{{ .Cluster }}-argo-workflows"
-    {{ if eq .Provider "google" }}
+    {{ else if $isGcp }}
     iam.gke.io/gcp-service-account: {{ importValue "Terraform" "service_account_email" }}
     {{ end }}
 
@@ -54,7 +56,7 @@ env:
     S3_BUCKET: {{ .Values.growthbookBucket }}
     S3_REGION: {{ .Region }}
 {{ end }}
-{{ if eq .Provider "gcp" }}
+{{ if $isGcp }}
   rest:
     UPLOAD_METHOD: google-cloud
     GCS_BUCKET_NAME: {{ .Values.growthbookBucket }}

--- a/harbor/helm/harbor/Chart.yaml
+++ b/harbor/helm/harbor/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: harbor
 description: helm chart for harbor
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: v2.8.1
 dependencies:
 - name: postgres

--- a/harbor/helm/harbor/values.yaml.tpl
+++ b/harbor/helm/harbor/values.yaml.tpl
@@ -1,3 +1,4 @@
+{{ $isGcp := or (eq .Provider "google") (eq .Provider "gcp") }}
 {{ $hostname := .Values.hostname }}
 {{ $notaryHostname := .Values.notaryHostname }}
 {{- $redisNamespace := namespace "redis" }}
@@ -47,7 +48,7 @@ harbor:
     imageChartStorage:
       {{- if eq .Provider "aws" }}
       type: s3
-      {{- else if eq .Provider "google" }}
+      {{- else if $isGcp }}
       type: gcs
       {{- else if eq .Provider "azure" }}
       type: azure
@@ -56,7 +57,7 @@ harbor:
       s3:
         region: {{ .Region }}
         bucket: {{ .Values.bucket }}
-      {{- else if eq .Provider "google" }}
+      {{- else if $isGcp }}
       gcs:
         bucket: {{ .Values.bucket }}
         useWorkloadIdentity: true
@@ -66,12 +67,12 @@ harbor:
         container: {{ .Values.bucket }}
         existingSecret: harbor-azure-secret
       {{- end }}
-{{- if or (eq .Provider "aws") (eq .Provider "google") }}
+{{- if or (eq .Provider "aws") $isGcp }}
 serviceAccount:
   annotations:
     {{- if eq .Provider "aws" }}
     eks.amazonaws.com/role-arn: {{ importValue "Terraform" "iam_role_arn" }}
-    {{- else if eq .Provider "google" }}
+    {{- else if $isGcp }}
     iam.gke.io/gcp-service-account: {{ importValue "Terraform" "service_account_email" }}
     {{- end }}
 {{- end }}

--- a/loki/helm/loki/Chart.yaml
+++ b/loki/helm/loki/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: loki
 description: helm chart for loki
 type: application
-version: 0.1.17
+version: 0.1.18
 appVersion: "v2.6.1"
 dependencies:
 - name: loki-distributed

--- a/loki/helm/loki/values.yaml.tpl
+++ b/loki/helm/loki/values.yaml.tpl
@@ -1,3 +1,4 @@
+{{ $isGcp := or (eq .Provider "google") (eq .Provider "gcp") }}
 {{ $traceShield := and .Configuration (index .Configuration "trace-shield") }}
 {{ $grafanaAgent := and .Configuration (index .Configuration "grafana-agent") }}
 {{ $tempo := and .Configuration .Configuration.tempo }}
@@ -44,7 +45,7 @@ datasource:
 {{- end }}
 
 loki-distributed:
-  {{- if eq .Provider "google" }}
+  {{- if $isGcp }}
   serviceAccount:
     create: false
   {{- end }}
@@ -107,7 +108,7 @@ loki-distributed:
             s3: s3://{{ .Region }}
             bucketnames: {{ .Values.lokiBucket }}
             region: {{ .Region }}
-          {{- else if eq .Provider "google" }}
+          {{- else if $isGcp }}
           gcs:
             bucket_name: {{ .Values.lokiBucket }}
           {{- else if eq .Provider "azure" }}
@@ -135,7 +136,7 @@ loki-distributed:
         storage:
           {{- if eq .Provider "aws" }}
           type: s3
-          {{- else if eq .Provider "google" }}
+          {{- else if $isGcp }}
           type: gcs
           {{- else if eq .Provider "azure" }}
           type: azure
@@ -151,7 +152,7 @@ loki-distributed:
           region: {{ .Region }}
         boltdb_shipper:
           shared_store: s3
-        {{- else if eq .Provider "google" }}
+        {{- else if $isGcp }}
         gcs:
           bucket_name: {{ .Values.lokiBucket }}
         boltdb_shipper:
@@ -175,7 +176,7 @@ loki-distributed:
             index:
               prefix: loki_index_
               period: 24h
-      {{- else if eq .Provider "google" }}
+      {{- else if $isGcp }}
       compactor:
         shared_store: gcs
       schema_config:

--- a/mimir/helm/mimir/Chart.yaml
+++ b/mimir/helm/mimir/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mimir
 description: helm chart for mimir
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: 2.7.1
 dependencies:
 - name: mimir-distributed

--- a/mimir/helm/mimir/values.yaml.tpl
+++ b/mimir/helm/mimir/values.yaml.tpl
@@ -1,3 +1,4 @@
+{{ $isGcp := or (eq .Provider "google") (eq .Provider "gcp") }}
 {{ $traceShield := and .Configuration (index .Configuration "trace-shield") }}
 {{ $grafanaAgent := and .Configuration (index .Configuration "grafana-agent") }}
 {{ $tempo := and .Configuration .Configuration.tempo }}
@@ -54,7 +55,7 @@ mimir-distributed:
   {{- if and .Values.basicAuth .Values.hostname (not $traceShield) }}
   gateway:
     enabledNonEnterprise: true
-    ingress: 
+    ingress:
       enabled: true
       annotations:
         nginx.ingress.kubernetes.io/auth-type: basic
@@ -84,7 +85,7 @@ mimir-distributed:
           s3:
             endpoint: s3.{{ .Region }}.amazonaws.com
             region: {{ .Region }}
-          {{- else if eq .Provider "google" }}
+          {{- else if $isGcp }}
           backend: gcs
           gcs:
           {{- else if eq .Provider "azure" }}
@@ -99,7 +100,7 @@ mimir-distributed:
         backend: s3
         s3:
           bucket_name: {{ .Values.mimirBlocksBucket }}
-        {{- else if eq .Provider "google" }}
+        {{- else if $isGcp }}
         backend: gcs
         gcs:
           bucket_name: {{ .Values.mimirBlocksBucket }}
@@ -115,7 +116,7 @@ mimir-distributed:
         backend: s3
         s3:
           bucket_name: {{ .Values.mimirAlertBucket }}
-        {{- else if eq .Provider "google" }}
+        {{- else if $isGcp }}
         backend: gcs
         gcs:
           bucket_name: {{ .Values.mimirAlertBucket }}
@@ -129,7 +130,7 @@ mimir-distributed:
         backend: s3
         s3:
           bucket_name: {{ .Values.mimirRulerBucket }}
-        {{- else if eq .Provider "google" }}
+        {{- else if $isGcp }}
         backend: gcs
         gcs:
           bucket_name: {{ .Values.mimirRulerBucket }}

--- a/postgres/helm/postgres/Chart.yaml
+++ b/postgres/helm/postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: postgres
 description: A Helm chart for deploying the zalando postgres operator
 type: application
-version: 0.2.13
+version: 0.2.14
 appVersion: "1.10.0"
 dependencies:
 - name: postgres-operator

--- a/postgres/helm/postgres/values.yaml.tpl
+++ b/postgres/helm/postgres/values.yaml.tpl
@@ -1,8 +1,9 @@
+{{ $isGcp := or (eq .Provider "google") (eq .Provider "gcp") }}
 postgres-operator:
   configAwsOrGcp:
   {{ if or (eq .Provider "aws") (eq .Provider "azure") (eq .Provider "equinix") (eq .Provider "kind") }}
     wal_s3_bucket: {{ .Values.wal_bucket }}
-  {{ else if eq .Provider "google" }}
+  {{ else if $isGcp }}
     additional_secret_mount: postgres-gcp-creds
     additional_secret_mount_path: "/var/secrets/google"
 

--- a/sftpgo/helm/sftpgo/Chart.yaml
+++ b/sftpgo/helm/sftpgo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sftpgo
 description: helm chart for sftpgo
 type: application
-version: 0.1.3
+version: 0.1.4
 icon: https://raw.githubusercontent.com/drakkan/sftpgo/main/img/logo.png
 appVersion: "v2.4.5"
 dependencies:

--- a/sftpgo/helm/sftpgo/values.yaml.tpl
+++ b/sftpgo/helm/sftpgo/values.yaml.tpl
@@ -1,3 +1,4 @@
+{{ $isGcp := or (eq .Provider "google") (eq .Provider "gcp") }}
 {{ $sftpgoPgPwd := dedupe . "sftpgo.postgres.password" (randAlphaNum 20) }}
 
 postgres:
@@ -36,7 +37,7 @@ sftpgo:
       service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '3600'
     {{ end }}
   {{ end }}
-{{ if eq .Provider "google" }}
+{{ if $isGcp }}
   serviceAccount:
     annotations:
       iam.gke.io/gcp-service-account: {{ importValue "Terraform" "gcp_sa_workload_identity_email" }}

--- a/vault/helm/vault/Chart.yaml
+++ b/vault/helm/vault/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vault
 description: A Helm chart for Hashicorp Vault on Plural
 type: application
-version: 0.2.5
+version: 0.2.6
 appVersion: 1.11.0
 dependencies:
 - name: vault

--- a/vault/helm/vault/values.yaml.tpl
+++ b/vault/helm/vault/values.yaml.tpl
@@ -1,3 +1,4 @@
+{{ $isGcp := or ($isGcp) (eq .Provider "gcp") }}
 global:
   application:
     links:
@@ -10,7 +11,7 @@ vault:
       {{- if eq .Provider "aws" }}
       VAULT_SEAL_TYPE: awskms
       {{- end }}
-      {{- if eq .Provider "google" }}
+      {{- if $isGcp }}
       VAULT_SEAL_TYPE: gcpckms
       GOOGLE_PROJECT: {{ .Project }}
       GOOGLE_REGION: {{ importValue "Terraform" "google_kms_key_ring_location" }}
@@ -25,7 +26,7 @@ vault:
       secretName: vault-env-secret
       secretKey: VAULT_AWSKMS_SEAL_KEY_ID
     {{- end }}
-    {{- if eq .Provider "google" }}
+    {{- if $isGcp }}
     - envName: VAULT_GCPCKMS_SEAL_CRYPTO_KEY
       secretName: vault-env-secret
       secretKey: VAULT_GCPCKMS_SEAL_CRYPTO_KEY
@@ -63,7 +64,7 @@ vault:
       annotations:
         eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Project }}:role/{{ .Cluster }}-vault"
     {{ end }}
-    {{ if eq .Provider "google" }}
+    {{ if $isGcp }}
     serviceAccount:
       create: false
       name: vault
@@ -73,7 +74,7 @@ envSecret:
   {{- if eq .Provider "aws" }}
   VAULT_AWSKMS_SEAL_KEY_ID: {{ importValue "Terraform" "aws_kms_key_id" }}
   {{- end }}
-  {{- if eq .Provider "google" }}
+  {{- if $isGcp }}
   VAULT_GCPCKMS_SEAL_KEY_RING: {{ importValue "Terraform" "google_kms_key_ring_name" }}
   VAULT_GCPCKMS_SEAL_CRYPTO_KEY: {{ importValue "Terraform" "google_kms_crypto_key_name" }}
   {{- end }}


### PR DESCRIPTION
## Summary
This PR updates various applications to ensure that both `google` and `gcp` can be returned as the `.Provider` by our CLI while we finish the provider name migration.