### PR TITLE
feat(bootstrap): add azure workload identity to recipe

### DIFF
--- a/bootstrap/plural/recipes/azure-k8s.yaml
+++ b/bootstrap/plural/recipes/azure-k8s.yaml
@@ -21,4 +21,6 @@ sections:
   - type: HELM
     name: azure-identity
   - type: HELM
+    name: azure-workload-identity
+  - type: HELM
     name: plural-certmanager-webhook


### PR DESCRIPTION
## Summary
This PR adds Azure Workload Identity to the regular Azure recipe so new users will also have it installed.