### PR TITLE
feat(ray): upgrade to aws eks 1.24

### DIFF
--- a/ray/terraform/aws/deps.yaml
+++ b/ray/terraform/aws/deps.yaml
@@ -2,12 +2,12 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: ray aws setup
-  version: 0.1.4
+  version: 0.1.5
 spec:
   dependencies:
   - name: aws-bootstrap
     repo: bootstrap
     type: terraform
-    version: '>= 0.1.51'
+    version: '>= 0.1.52'
   providers:
   - aws

--- a/ray/terraform/aws/variables.tf
+++ b/ray/terraform/aws/variables.tf
@@ -32,7 +32,7 @@ variable "node_groups_defaults" {
 
     instance_types       = ["t3.large", "t3a.large"]
     disk_size            = 50
-    ami_release_version  = "1.23.16-20230217"
+    ami_release_version  = "1.24.15-20230816"
     force_update_version = true
     ami_type             = "AL2_x86_64"
     k8s_labels           = {}


### PR DESCRIPTION
## Summary
This PR upgrades the Ray node groups to EKS 1.24.