### PR TITLE
feat(bootstrap): add cluster api cluster chart

### DIFF
--- a/.github/workflows/cluster-chart-unit-test.yml
+++ b/.github/workflows/cluster-chart-unit-test.yml
@@ -1,0 +1,27 @@
+name: cluster-chart-unit-test
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'bootstrap/helm/cluster-api-cluster/**'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'bootstrap/helm/cluster-api-cluster/**'
+jobs:
+  helm-unit-test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: install helm
+      uses: azure/setup-helm@v3
+      with:
+        version: v3.12.3
+    - name: install helm unit test
+      run: helm plugin install https://github.com/helm-unittest/helm-unittest.git
+    - name: run helm unit test
+      run: helm unittest ./bootstrap/helm/cluster-api-cluster

--- a/bootstrap/helm/cluster-api-cluster/.helmignore
+++ b/bootstrap/helm/cluster-api-cluster/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+tests/

--- a/bootstrap/helm/cluster-api-cluster/Chart.yaml
+++ b/bootstrap/helm/cluster-api-cluster/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: cluster-api-cluster
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.42
+appVersion: v1.24.16

--- a/bootstrap/helm/cluster-api-cluster/README.md
+++ b/bootstrap/helm/cluster-api-cluster/README.md
@@ -1,0 +1,3 @@
+# Cluster API Cluster
+
+A helm chart that deploys a cluster using the Cluster-API project

--- a/bootstrap/helm/cluster-api-cluster/deps.yaml
+++ b/bootstrap/helm/cluster-api-cluster/deps.yaml
@@ -1,0 +1,7 @@
+apiVersion: plural.sh/v1alpha1
+kind: Dependencies
+metadata:
+  application: true
+  description: installs a cluster using cluster-api
+spec:
+  dependencies: []

--- a/bootstrap/helm/cluster-api-cluster/templates/_helpers.tpl
+++ b/bootstrap/helm/cluster-api-cluster/templates/_helpers.tpl
@@ -1,0 +1,237 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cluster-api-cluster.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cluster-api-cluster.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cluster-api-cluster.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cluster-api-cluster.labels" -}}
+helm.sh/chart: {{ include "cluster-api-cluster.chart" . }}
+{{ include "cluster-api-cluster.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cluster-api-cluster.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cluster-api-cluster.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cluster-api-cluster.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "cluster-api-cluster.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Creates the Kubernetes version for the cluster
+# TODO: this should actually be used to sanatize the `.Values.cluster.kubernetesVersion` value to what the providers support instead of defining these static versions
+*/}}
+{{- define "cluster.kubernetesVersion" -}}
+{{- if .Values.cluster.kubernetesVersion -}}
+{{ .Values.cluster.kubernetesVersion }}
+{{- else if eq .Values.provider "aws" -}}
+v1.24
+{{- else if eq .Values.provider "azure" -}}
+v1.25.11
+{{- else if and (eq .Values.provider "gcp") (eq .Values.type "managed") -}}
+1.24.16
+{{- else if eq .Values.provider "kind" -}}
+v1.25.11
+{{- end }}
+{{- end }}
+
+{{/*
+Create the kind for the infrastructureRef for the cluster
+*/}}
+{{- define "cluster.infrastructure.kind" -}}
+{{- if and (eq .Values.provider "aws") (eq .Values.type "managed") -}}
+AWSManagedCluster
+{{- end }}
+{{- if and (eq .Values.provider "azure") (eq .Values.type "managed") -}}
+AzureManagedCluster
+{{- end }}
+{{- if and (eq .Values.provider "gcp") (eq .Values.type "managed") -}}
+GCPManagedCluster
+{{- end }}
+{{- if and (eq .Values.provider "kind") (eq .Values.type "managed") -}}
+DockerCluster
+{{- end }}
+{{- end }}
+
+{{/*
+Create the apiVersion for the infrastructureRef for the cluster
+*/}}
+{{- define "cluster.infrastructure.apiVersion" -}}
+{{- if and (eq .Values.provider "aws") (eq .Values.type "managed") -}}
+infrastructure.cluster.x-k8s.io/v1beta2
+{{- end }}
+{{- if and (eq .Values.provider "azure") (eq .Values.type "managed") -}}
+infrastructure.cluster.x-k8s.io/v1beta1
+{{- end }}
+{{- if and (eq .Values.provider "gcp") (eq .Values.type "managed") -}}
+infrastructure.cluster.x-k8s.io/v1beta1
+{{- end }}
+{{- if and (eq .Values.provider "kind") (eq .Values.type "managed") -}}
+infrastructure.cluster.x-k8s.io/v1beta1
+{{- end }}
+{{- end }}
+
+{{/*
+Create the kind for the controlPlaneRef for the cluster
+*/}}
+{{- define "cluster.controlPlane.kind" -}}
+{{- if and (eq .Values.provider "aws") (eq .Values.type "managed") -}}
+AWSManagedControlPlane
+{{- end }}
+{{- if and (eq .Values.provider "azure") (eq .Values.type "managed") -}}
+AzureManagedControlPlane
+{{- end }}
+{{- if and (eq .Values.provider "gcp") (eq .Values.type "managed") -}}
+GCPManagedControlPlane
+{{- end }}
+{{- if and (eq .Values.provider "kind") (eq .Values.type "managed") -}}
+KubeadmControlPlane
+{{- end }}
+{{- end }}
+
+{{/*
+Create the apiVersion for the controlPlaneRef for the cluster
+*/}}
+{{- define "cluster.controlPlane.apiVersion" -}}
+{{- if and (eq .Values.provider "aws") (eq .Values.type "managed") -}}
+controlplane.cluster.x-k8s.io/v1beta2
+{{- end }}
+{{- if and (eq .Values.provider "azure") (eq .Values.type "managed") -}}
+infrastructure.cluster.x-k8s.io/v1beta1
+{{- end }}
+{{- if and (eq .Values.provider "gcp") (eq .Values.type "managed") -}}
+infrastructure.cluster.x-k8s.io/v1beta1
+{{- end }}
+{{- if and (eq .Values.provider "kind") (eq .Values.type "managed") -}}
+controlplane.cluster.x-k8s.io/v1beta1
+{{- end }}
+{{- end }}
+
+{{/*
+Create the kind for the infrastructureRef for the worker MachinePools
+*/}}
+{{- define "workers.infrastructure.kind" -}}
+{{- if and (eq .Values.provider "aws") (eq .Values.type "managed") -}}
+AWSManagedMachinePool
+{{- end }}
+{{- if and (eq .Values.provider "azure") (eq .Values.type "managed") -}}
+AzureManagedMachinePool
+{{- end }}
+{{- if and (eq .Values.provider "gcp") (eq .Values.type "managed") -}}
+GCPManagedMachinePool
+{{- end }}
+{{- if and (eq .Values.provider "kind") (eq .Values.type "managed") -}}
+DockerMachinePool
+{{- end }}
+{{- end }}
+
+{{/*
+Create the apiVersion for the infrastructureRef for the worker MachinePools
+*/}}
+{{- define "workers.infrastructure.apiVersion" -}}
+{{- if and (eq .Values.provider "aws") (eq .Values.type "managed") -}}
+infrastructure.cluster.x-k8s.io/v1beta2
+{{- end }}
+{{- if and (eq .Values.provider "azure") (eq .Values.type "managed") -}}
+infrastructure.cluster.x-k8s.io/v1beta1
+{{- end }}
+{{- if and (eq .Values.provider "gcp") (eq .Values.type "managed") -}}
+infrastructure.cluster.x-k8s.io/v1beta1
+{{- end }}
+{{- if and (eq .Values.provider "kind") (eq .Values.type "managed") -}}
+infrastructure.cluster.x-k8s.io/v1beta1
+{{- end }}
+{{- end }}
+
+{{/*
+Create the configRef for the worker MachinePools
+*/}}
+{{- define "workers.configref" -}}
+{{- if and (eq .Values.provider "kind") (eq .Values.type "managed") -}}
+configRef:
+  apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+  kind: KubeadmConfig
+  name: worker-mp-config
+{{- end }}
+{{- end }}
+
+{{/*
+Create a MachinePool for the given values
+  ctx = . context
+  name = the name of the MachinePool resource
+  values = the values for this specific MachinePool resource
+  defaultVals = the default values for the MachinePool resource
+*/}}
+{{- define "workers.machinePool" -}}
+{{- $replicas := (.values | default dict).replicas | default .defaultVals.replicas }}
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachinePool
+metadata:
+  name: {{ .name }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  clusterName: {{ .ctx.Values.cluster.name }}
+  replicas: {{ $replicas }}
+  template:
+    spec:
+      {{- if or (eq .ctx.Values.provider "gcp") (eq .ctx.Values.provider "azure") (eq .ctx.Values.provider "kind") }}
+      version: {{ .values.kubernetesVersion | default (include "cluster.kubernetesVersion" .ctx) | quote }}
+      {{- end }}
+      clusterName: {{ .ctx.Values.cluster.name }}
+      bootstrap:
+        {{- if or (eq .ctx.Values.provider "gcp") (eq .ctx.Values.provider "azure") (eq .ctx.Values.provider "aws") }}
+        dataSecretName: ""
+        {{- end }}
+        {{- if eq .ctx.Values.provider "kind" }}
+        {{- include "workers.configref" .ctx | nindent 8 }}
+        {{- end }}
+      infrastructureRef:
+        name: {{ .name }}
+        apiVersion: {{ include "workers.infrastructure.apiVersion" .ctx }}
+        kind: {{ include "workers.infrastructure.kind" .ctx }}
+{{- end }}

--- a/bootstrap/helm/cluster-api-cluster/templates/aws/_helpers.tpl
+++ b/bootstrap/helm/cluster-api-cluster/templates/aws/_helpers.tpl
@@ -1,0 +1,100 @@
+{{/*
+Function to template an AWSManagedMachinePool resource.
+Params:
+  ctx = . context
+  name = the name of the AWSManagedMachinePool resource
+  defaultVals = the default values for the AWSManagedMachinePool resource
+  values = the values for this specific AWSManagedMachinePool resource
+  availabilityZones = the availability zones for the AWSManagedMachinePool
+*/}}
+{{- define "workers.aws.managedMachinePool" -}}
+{{- $validAmiTypes := (list "AL2_x86_64" "AL2_x86_64_GPU" "AL2_ARM_64") -}}
+{{- $validCapacityTypes := (list "onDemand" "spot") -}}
+{{- $amiType := (.values.spec | default dict).amiType | default .defaultVals.spec.amiType }}
+{{- if not (has $amiType $validAmiTypes) }}
+  {{- fail (printf "Invalid value for amiType: %s. Expected one of: %s" $amiType $validAmiTypes) }}
+{{- end }}
+{{- $capacityType := (.values.spec | default dict).capacityType | default .defaultVals.spec.capacityType }}
+{{- if not (has $capacityType $validCapacityTypes) }}
+  {{- fail (printf "Invalid value for capacityType: %s. Expected one of: %s" $capacityType $validCapacityTypes) }}
+{{- end }}
+{{- $scaling := (.values.spec | default dict).scaling | default .defaultVals.spec.scaling }}
+{{- if $scaling }}
+{{- if not (and (hasKey $scaling "minSize") (hasKey $scaling "maxSize")) }}
+  {{- fail (printf "Invalid value for scaling. Both minSize and maxSize must be set") }}
+{{- end }}
+{{- end }}
+{{- $updateConfig := (.values.spec | default dict).updateConfig | default .defaultVals.spec.updateConfig }}
+{{- if $updateConfig }}
+{{- if and (hasKey $updateConfig "maxUnavailable") (hasKey $updateConfig "maxSurge") }}
+  {{- fail (printf "Invalid value for updateConfig. Only one of maxUnavailable and maxSurge can be set") }}
+{{- end }}
+{{- end }}
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSManagedMachinePool
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+    {{- if (hasKey .values "annotations") -}}
+    {{- toYaml (merge .values.annotations .defaultVals.annotations)| nindent 4 }}
+    {{- else -}}
+    {{- toYaml .defaultVals.annotations | nindent 4 }}
+    {{- end }}
+  labels:
+    {{- if (hasKey .values "labels") -}}
+    {{- toYaml (merge .values.labels .defaultVals.labels)| nindent 4 }}
+    {{- else -}}
+    {{- toYaml .defaultVals.labels | nindent 4 }}
+    {{- end }}
+  name: {{ .name }}
+spec:
+  amiType: {{ $amiType }}
+  amiVersion: {{ (.values.spec | default dict).amiVersion | default .defaultVals.spec.amiVersion }}
+  capacityType: {{ $capacityType }}
+  diskSize: {{ (.values.spec | default dict).diskSize | default .defaultVals.spec.diskSize }}
+  eksNodegroupName: {{ .name }}
+  instanceType: {{ (.values.spec | default dict).instanceType | default .defaultVals.spec.instanceType }}
+  {{- if or (.defaultVals.spec.roleName) ((.values.spec | default dict).roleName) }}
+  roleName: {{ (.values.spec | default dict).roleName | default .defaultVals.spec.roleName }}
+  {{- end }}
+  {{- if $scaling }}
+  scaling:
+    {{- toYaml $scaling | nindent 4 }}
+  {{- end }}
+  {{- if .availabilityZones }}
+  availabilityZones: {{- toYaml .availabilityZones | nindent 2 }}
+  {{- end}}
+  {{- if or (.defaultVals.spec.subnetIDs) ((.values.spec | default dict).subnetIDs) }}
+  subnetIDs:
+  {{- toYaml ((.values.spec | default dict).subnetIDs | default .defaultVals.spec.subnetIDs) | nindent 2 }}
+  {{- end }}
+  labels:
+    {{- if (dig "spec" "labels" .values) -}}
+    {{- toYaml (merge .values.spec.labels .defaultVals.spec.labels)| nindent 4 }}
+    {{- else -}}
+    {{- toYaml .defaultVals.spec.labels | nindent 4 }}
+    {{- end }}
+    {{- if eq (len .availabilityZones) 1 }}
+    topology.ebs.csi.aws.com/zone: {{ index .availabilityZones 0 }}
+    {{- end }}
+  {{- if or (.defaultVals.spec.taints) ((.values.spec | default dict).taints) }}
+  taints:
+  {{- toYaml ((.values.spec | default dict).taints | default .defaultVals.spec.taints) | nindent 2 }}
+  {{- end }}
+  {{- if $updateConfig }}
+  updateConfig:
+    {{- toYaml $updateConfig | nindent 4 }}
+  {{- end }}
+  additionalTags:
+    {{- if (dig "spec" "additionalTags" .values) }}
+    {{- toYaml (merge .values.spec.additionalTags .defaultVals.spec.additionalTags) | nindent 4 }}
+    {{- else -}}
+    {{- toYaml .defaultVals.spec.additionalTags | nindent 4 }}
+    {{- end }}
+  {{- if or (.defaultVals.spec.roleAdditionalPolicies) ((.values.spec | default dict).roleAdditionalPolicies) }}
+  roleAdditionalPolicies:
+  {{- toYaml ((.values.spec | default dict).roleAdditionalPolicies | default .defaultVals.spec.roleAdditionalPolicies) | nindent 2 }}
+  {{- end }}
+---
+{{- include "workers.machinePool" (dict "ctx" .ctx "name" .name "values" .values "defaultVals" .defaultVals) }}
+{{- end }}

--- a/bootstrap/helm/cluster-api-cluster/templates/aws/cluster.yaml
+++ b/bootstrap/helm/cluster-api-cluster/templates/aws/cluster.yaml
@@ -1,0 +1,17 @@
+{{- if and (eq .Values.provider "aws") (eq .Values.type "managed") -}}
+kind: AWSManagedCluster
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+metadata:
+  name: {{ .Values.cluster.name }}
+  annotations:
+    helm.sh/resource-policy: keep
+  {{- if .Values.cluster.aws.controlPlaneEndpoint}}
+  {{- with .Values.cluster.aws.controlPlaneEndpoint }}
+spec:
+  controlPlaneEndpoint:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- else }}
+spec: {}
+  {{- end }}
+{{- end }}

--- a/bootstrap/helm/cluster-api-cluster/templates/aws/control-plane.yaml
+++ b/bootstrap/helm/cluster-api-cluster/templates/aws/control-plane.yaml
@@ -1,0 +1,84 @@
+{{- if and (eq .Values.provider "aws") (eq .Values.type "managed") -}}
+kind: AWSManagedControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+metadata:
+  name: {{ .Values.cluster.name }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  region: {{ .Values.cluster.aws.region }}
+  sshKeyName: {{ .Values.cluster.aws.sshKeyName }}
+  version: {{ include "cluster.kubernetesVersion" . }}
+  {{- with .Values.cluster.aws.addons }}
+  addons:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  eksClusterName: {{ .Values.cluster.name }}
+  {{- with .Values.cluster.aws.network }}
+  network:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.cluster.aws.identityRef }}
+  identityRef:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.cluster.aws.secondaryCidrBlock }}
+  secondaryCidrBlock: {{ .Values.cluster.aws.secondaryCidrBlock }}
+  {{- end }}
+  {{- if .Values.cluster.aws.roleName }}
+  roleName: {{ .Values.cluster.aws.roleName }}
+  {{- end }}
+  {{- with .Values.cluster.aws.roleAdditionalPolicies }}
+  roleAdditionalPolicies:
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- with .Values.cluster.aws.logging }}
+  logging:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.cluster.aws.encryptionConfig }}
+  encryptionConfig:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.cluster.aws.additionalTags }}
+  additionalTags:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if or (.Values.cluster.aws.iamAuthenticatorConfig.mapRoles) (.Values.cluster.aws.iamAuthenticatorConfig.mapUsers) }}
+  iamAuthenticatorConfig:
+    {{- with .Values.cluster.aws.iamAuthenticatorConfig.mapRoles }}
+    mapRoles:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.cluster.aws.iamAuthenticatorConfig.mapUsers }}
+    mapUsers:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  {{- with .Values.cluster.aws.endpointAccess }}
+  endpointAccess:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.cluster.aws.bastion }}
+  bastion:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.cluster.aws.tokenMethod }}
+  tokenMethod: {{ .Values.cluster.aws.tokenMethod }}
+  {{- end }}
+  {{- if .Values.cluster.aws.associateOIDCProvider }}
+  associateOIDCProvider: {{ .Values.cluster.aws.associateOIDCProvider }}
+  {{- end }}
+  {{- with .Values.cluster.aws.oidcIdentityProviderConfig }}
+  oidcIdentityProviderConfig:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.cluster.aws.vpcCni }}
+  vpcCni:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.cluster.aws.kubeProxy }}
+  kubeProxy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/bootstrap/helm/cluster-api-cluster/templates/aws/machinepools.yaml
+++ b/bootstrap/helm/cluster-api-cluster/templates/aws/machinepools.yaml
@@ -1,0 +1,22 @@
+{{- if and (eq .Values.provider "aws") (eq .Values.type "managed") -}}
+{{- $currentScope := . -}}
+{{- $defaultVals := .Values.workers.defaults.aws -}}
+{{- range $name, $values := .Values.workers.aws }}
+{{- with $currentScope }}
+{{- $isMultiAZ := ($values | default dict).isMultiAZ | default $defaultVals.isMultiAZ }}
+{{- $availabilityZones := ($values.spec | default dict).availabilityZones | default $defaultVals.spec.availabilityZones }}
+{{- if and (not $isMultiAZ) (not $availabilityZones) }}
+  {{- fail (printf "Invalid value for isMultiAZ. availabilityZones must be set") }}
+{{- end }}
+{{- if not $isMultiAZ }}
+{{ range $az := $availabilityZones }}
+{{- include "workers.aws.managedMachinePool" (dict "ctx" $currentScope "name" (printf "%s-%s" $name $az) "defaultVals" $defaultVals "values" $values "availabilityZones" (list $az)) }}
+---
+{{- end }}
+{{- else }}
+{{- include "workers.aws.managedMachinePool" (dict "ctx" $currentScope "name" $name "defaultVals" $defaultVals "values" $values "availabilityZones" $availabilityZones) }}
+---
+{{- end }}
+{{- end }}
+{{- end }}
+{{ end }}

--- a/bootstrap/helm/cluster-api-cluster/templates/azure/_helpers.tpl
+++ b/bootstrap/helm/cluster-api-cluster/templates/azure/_helpers.tpl
@@ -1,0 +1,112 @@
+{{/*
+Name of the AzureClusterIdentity used for bootstrapping
+*/}}
+{{- define "azure-bootstrap.cluster-identity-name" -}}
+{{- printf "%s-azure-bootstrap-identity" .Release.Name | trunc 63 }}
+{{- end }}
+
+{{/*
+Name of the secret for the AzureClusterIdentity used for bootstrapping
+*/}}
+{{- define "azure-bootstrap.identity-credentials" -}}
+{{- printf "%s-azure-bootstrap-credentials" .Release.Name | trunc 63 }}
+{{- end }}
+
+{{/*
+Name of the AAD Pod Identity used for bootstrapping
+*/}}
+{{- define "azure-bootstrap.pod-identity-name" -}}
+{{- printf "%s-%s-%s" .Values.cluster.name .Release.Namespace (include "azure-bootstrap.cluster-identity-name" .) }}
+{{- end }}
+
+{{/*
+Name of the AAD Pod Identity Binding used for bootstrapping
+*/}}
+{{- define "azure-bootstrap.pod-identity-binding" -}}
+{{- printf "%s-binding" (include "azure-bootstrap.pod-identity-name" .) }}
+{{- end }}
+
+{{/*
+Function to template an AzureManagedMachinePool resource.
+Params:
+  ctx = . context
+  name = the name of the AzureManagedMachinePool resource
+  defaultVals = the default values for the AzureManagedMachinePool resource
+  values = the values for this specific AzureManagedMachinePool resource
+  availabilityZones = the availability zones for the AzureManagedMachinePool
+*/}}
+{{- define "workers.azure.managedMachinePool" -}}
+{{- $scaling := (.values.spec | default dict).scaling | default .defaultVals.spec.scaling }}
+{{- if $scaling }}
+{{- if not (and (hasKey $scaling "minSize") (hasKey $scaling "maxSize")) }}
+  {{- fail (printf "Invalid value for scaling. Both minSize and maxSize must be set") }}
+{{- end }}
+{{- end }}
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureManagedMachinePool
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+    {{- if (hasKey .values "annotations") -}}
+    {{- toYaml (merge .values.annotations .defaultVals.annotations)| nindent 4 }}
+    {{- else -}}
+    {{- toYaml .defaultVals.annotations | nindent 4 }}
+    {{- end }}
+  labels:
+    {{- if (hasKey .values "labels") -}}
+    {{- toYaml (merge .values.labels .defaultVals.labels)| nindent 4 }}
+    {{- else -}}
+    {{- toYaml .defaultVals.labels | nindent 4 }}
+    {{- end }}
+  name: {{ .name }}
+spec:
+  name: {{ .name }}
+  additionalTags:
+    {{- if (dig "spec" "additionalTags" .values) -}}
+    {{- toYaml (merge .values.spec.additionalTags .defaultVals.spec.additionalTags)| nindent 4 }}
+    {{- else }}
+    {{- toYaml .defaultVals.spec.additionalTags | nindent 4 }}
+    {{- end }}
+  mode: {{ (.values.spec | default dict).mode | default .defaultVals.spec.mode }}
+  sku: {{ (.values.spec | default dict).sku | default .defaultVals.spec.sku }}
+  osDiskSizeGB: {{ (.values.spec | default dict).osDiskSizeGB | default .defaultVals.spec.osDiskSizeGB }}
+  availabilityZones: {{- toYaml .availabilityZones | nindent 2 }}
+  nodeLabels:
+    {{- if (dig "spec" "nodeLabels" .values) -}}
+    {{- toYaml (merge .values.spec.nodeLabels .defaultVals.spec.nodeLabels)| nindent 4 }}
+    {{- else -}}
+    {{- toYaml .defaultVals.spec.nodeLabels | nindent 4 }}
+    {{- end }}
+  {{- if or (.defaultVals.spec.taints) ((.values.spec | default dict).taints) }}
+  taints:
+  {{- toYaml ((.values.spec | default dict).taints | default .defaultVals.spec.taints) | nindent 2 }}
+  {{- end }}
+  {{- if $scaling }}
+  scaling:
+    {{- toYaml $scaling | nindent 4 }}
+  {{- end }}
+  {{- if or (.defaultVals.spec.scaleDownMode) ((.values.spec | default dict).scaleDownMode) }}
+  scaleDownMode: {{ (.values.spec | default dict).scaleDownMode | default .defaultVals.spec.scaleDownMode }}
+  {{- end }}
+  {{- if or (.defaultVals.spec.spotMaxPrice) ((.values.spec | default dict).spotMaxPrice) }}
+  spotMaxPrice: {{ (.values.spec | default dict).spotMaxPrice | default .defaultVals.spec.spotMaxPrice }}
+  {{- end }}
+  maxPods: {{ (.values.spec | default dict).maxPods | default .defaultVals.spec.maxPods }}
+  osDiskType: {{ (.values.spec | default dict).osDiskType | default .defaultVals.spec.osDiskType }}
+  {{- if or (.defaultVals.spec.scaleSetPriority) ((.values.spec | default dict).scaleSetPriority) }}
+  scaleSetPriority: {{ (.values.spec | default dict).scaleSetPriority | default .defaultVals.spec.scaleSetPriority }}
+  {{- end }}
+  osType: {{ (.values.spec | default dict).osType | default .defaultVals.spec.osType }}
+  enableNodePublicIP: {{ (.values.spec | default dict).enableNodePublicIP | default .defaultVals.spec.enableNodePublicIP }}
+  nodePublicIPPrefixID: {{ (.values.spec | default dict).nodePublicIPPrefixID | default .defaultVals.spec.nodePublicIPPrefixID }}
+  {{- if or (.defaultVals.spec.kubeletConfig) ((.values.spec | default dict).kubeletConfig) }}
+  kubeletConfig:
+    {{- toYaml ((.values.spec | default dict).kubeletConfig | default .defaultVals.spec.kubeletConfig) | nindent 2 }}
+  {{- end }}
+  {{- if or (.defaultVals.spec.linuxOSConfig) ((.values.spec | default dict).linuxOSConfig) }}
+  linuxOSConfig:
+    {{- toYaml ((.values.spec | default dict).linuxOSConfig | default .defaultVals.spec.linuxOSConfig) | nindent 2 }}
+  {{- end }}
+---
+{{- include "workers.machinePool" (dict "ctx" .ctx "name" .name "values" .values "defaultVals" .defaultVals) }}
+{{- end }}

--- a/bootstrap/helm/cluster-api-cluster/templates/azure/bootstrap-cluster-identity.yaml
+++ b/bootstrap/helm/cluster-api-cluster/templates/azure/bootstrap-cluster-identity.yaml
@@ -1,0 +1,62 @@
+{{- if and (eq .Values.provider "azure") (eq .Values.type "managed") .Values.cluster.azure.clusterIdentity.bootstrapMode -}}
+kind: AzureClusterIdentity
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+metadata:
+  name: {{ include "azure-bootstrap.cluster-identity-name" . }}
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
+  {{- include "cluster-api-cluster.labels" . | nindent 4 }}
+spec:
+  type: ServicePrincipal
+  allowedNamespaces: {}
+  tenantID: {{ .Values.cluster.azure.clusterIdentity.tenantID }}
+  clientID: {{ .Values.cluster.azure.clusterIdentity.bootstrapCredentials.clientID }}
+  clientSecret:
+    name: {{ include "azure-bootstrap.identity-credentials" . }}
+    namespace: {{ .Release.Namespace }}
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ include "azure-bootstrap.identity-credentials" . }}
+  labels:
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
+  {{- include "cluster-api-cluster.labels" . | nindent 4 }}
+type: Opaque
+data:
+  clientSecret: {{ .Values.cluster.azure.clusterIdentity.bootstrapCredentials.clientSecret | b64enc | quote }}
+---
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentity
+metadata:
+  name: {{ include "azure-bootstrap.pod-identity-name" . }}
+  labels:
+    azurecluster.infrastructure.cluster.x-k8s.io/cluster-namespace: {{ .Release.Namespace }}
+    cluster.x-k8s.io/cluster-name: {{ .Values.cluster.name }}
+    clusterctl.cluster.x-k8s.io/move-hierarchy: 'true'
+  {{- include "cluster-api-cluster.labels" . | nindent 4 }}
+  annotations:
+    aadpodidentity.k8s.io/Behavior: namespaced
+spec:
+  adEndpoint: https://login.microsoftonline.com/
+  adResourceID: https://management.azure.com/
+  clientID: {{ .Values.cluster.azure.clusterIdentity.bootstrapCredentials.clientID }}
+  clientPassword:
+    name: {{ include "azure-bootstrap.identity-credentials" . }}
+    namespace: {{ .Release.Namespace }}
+  tenantID: {{ .Values.cluster.azure.clusterIdentity.tenantID }}
+  type: 1
+---
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentityBinding
+metadata:
+  name: {{ include "azure-bootstrap.pod-identity-binding" . }}
+  labels:
+    azurecluster.infrastructure.cluster.x-k8s.io/cluster-namespace: {{ .Release.Namespace }}
+    cluster.x-k8s.io/cluster-name: {{ .Values.cluster.name }}
+    clusterctl.cluster.x-k8s.io/move-hierarchy: 'true'
+  {{- include "cluster-api-cluster.labels" . | nindent 4 }}
+spec:
+  azureIdentity: {{ include "azure-bootstrap.pod-identity-name" . }}
+  selector: capz-controller-aadpodidentity-selector
+{{- end }}

--- a/bootstrap/helm/cluster-api-cluster/templates/azure/cluster-workload-identity.yaml
+++ b/bootstrap/helm/cluster-api-cluster/templates/azure/cluster-workload-identity.yaml
@@ -1,0 +1,16 @@
+{{- if and (eq .Values.provider "azure") (eq .Values.type "managed") (not .Values.cluster.azure.clusterIdentity.bootstrapMode) .Values.cluster.azure.clusterIdentity.workloadIdentity.enabled }}
+kind: AzureClusterIdentity
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+metadata:
+  name: {{ .Values.cluster.azure.clusterIdentity.workloadIdentity.name }}
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-azure
+    clusterctl.cluster.x-k8s.io/move-hierarchy: "true"
+  {{- include "cluster-api-cluster.labels" . | nindent 4 }}
+spec:
+  type: WorkloadIdentity
+  allowedNamespaces:
+    {{- toYaml .Values.cluster.azure.clusterIdentity.workloadIdentity.allowedNamespaces | nindent 4 }}
+  clientID: {{ .Values.cluster.azure.clusterIdentity.workloadIdentity.clientID }}
+  tenantID: {{ .Values.cluster.azure.clusterIdentity.tenantID }}
+{{- end }}

--- a/bootstrap/helm/cluster-api-cluster/templates/azure/cluster.yaml
+++ b/bootstrap/helm/cluster-api-cluster/templates/azure/cluster.yaml
@@ -1,0 +1,9 @@
+{{- if and (eq .Values.provider "azure") (eq .Values.type "managed") -}}
+kind: AzureManagedCluster
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+metadata:
+  name: {{ .Values.cluster.name }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec: {}
+{{- end }}

--- a/bootstrap/helm/cluster-api-cluster/templates/azure/control-plane.yaml
+++ b/bootstrap/helm/cluster-api-cluster/templates/azure/control-plane.yaml
@@ -1,0 +1,65 @@
+{{- if and (eq .Values.provider "azure") (eq .Values.type "managed") -}}
+kind: AzureManagedControlPlane
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+metadata:
+  name: {{ .Values.cluster.name }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  identityRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: AzureClusterIdentity
+    {{- if .Values.cluster.azure.clusterIdentity.bootstrapMode }}
+    name: {{ include "azure-bootstrap.cluster-identity-name" . }}
+    {{- else if .Values.cluster.azure.clusterIdentity.workloadIdentity.enabled }}
+    name: {{ .Values.cluster.azure.clusterIdentity.workloadIdentity.name }}
+    {{- else }}
+    name: {{ .Values.cluster.azure.clusterIdentity.name }}
+    {{- end }}
+    namespace: {{ .Release.Namespace }}
+  location: {{ .Values.cluster.azure.location }}
+  resourceGroupName: {{ .Values.cluster.azure.resourceGroupName }}
+  nodeResourceGroupName: {{ .Values.cluster.azure.nodeResourceGroupName }}
+  subscriptionID: {{ .Values.cluster.azure.subscriptionID }}
+  version: {{ include "cluster.kubernetesVersion" . }}
+  {{- if ne .Values.cluster.azure.sshPublicKey "skip" }}
+  sshPublicKey: {{ .Values.cluster.azure.sshPublicKey | quote }}
+  {{- end }}
+  {{- with .Values.cluster.azure.virtualNetwork }}
+  virtualNetwork:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  networkPlugin: {{ .Values.cluster.azure.networkPlugin }}
+  networkPolicy: {{ .Values.cluster.azure.networkPolicy }}
+  outboundType: {{ .Values.cluster.azure.outboundType }}
+  dnsServiceIP: {{ .Values.cluster.azure.dnsServiceIP }}
+  {{- with .Values.cluster.azure.identity }}
+  identity:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.cluster.azure.sku }}
+  sku:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  loadBalancerSKU: {{ .Values.cluster.azure.loadBalancerSKU }}
+  {{- with .Values.cluster.azure.aadProfile }}
+  aadProfile:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.cluster.azure.loadBalancerProfile }}
+  loadBalancerProfile:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.cluster.azure.apiServerAccessProfile }}
+  apiServerAccessProfile:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.cluster.azure.autoscalerProfile }}
+  autoscalerProfile:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.cluster.azure.addonProfiles }}
+  addonProfiles:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/bootstrap/helm/cluster-api-cluster/templates/azure/machine-pools.yaml
+++ b/bootstrap/helm/cluster-api-cluster/templates/azure/machine-pools.yaml
@@ -1,0 +1,22 @@
+{{- if and (eq .Values.provider "azure") (eq .Values.type "managed") -}}
+{{- $currentScope := . -}}
+{{- $defaultVals := .Values.workers.defaults.azure -}}
+{{- range $name, $values := .Values.workers.azure }}
+{{- with $currentScope}}
+{{- $isMultiAZ := ($values | default dict).isMultiAZ | default $defaultVals.isMultiAZ }}
+{{- $availabilityZones := ($values.spec | default dict).availabilityZones | default $defaultVals.spec.availabilityZones }}
+{{- if and (not $isMultiAZ) (not $availabilityZones) }}
+  {{- fail (printf "Invalid value for isMultiAZ. availabilityZones must be set") }}
+{{- end }}
+{{- if not $isMultiAZ }}
+{{ range $az := $availabilityZones }}
+{{- include "workers.azure.managedMachinePool" (dict "ctx" $currentScope "name" (printf "%s%s" $name $az) "defaultVals" $defaultVals "values" $values "availabilityZones" (list $az)) }}
+---
+{{- end }}
+{{- else }}
+{{- include "workers.azure.managedMachinePool" (dict "ctx" $currentScope "name" $name "defaultVals" $defaultVals "values" $values "availabilityZones" $availabilityZones) }}
+---
+{{- end }}
+{{- end }}
+{{- end }}
+{{ end }}

--- a/bootstrap/helm/cluster-api-cluster/templates/cluster.yaml
+++ b/bootstrap/helm/cluster-api-cluster/templates/cluster.yaml
@@ -1,0 +1,24 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: {{ .Values.cluster.name }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  clusterNetwork:
+    {{- with .Values.cluster.podCidrBlocks }}
+    pods:
+      cidrBlocks: {{ toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.cluster.serviceCidrBlocks }}
+    services:
+      cidrBlocks: {{ toYaml . | nindent 6 }}
+    {{- end }}
+  infrastructureRef:
+    kind: {{ include "cluster.infrastructure.kind" . }}
+    apiVersion: {{ include "cluster.infrastructure.apiVersion" . }}
+    name: {{ .Values.cluster.name }}
+  controlPlaneRef:
+    kind: {{ include "cluster.controlPlane.kind" . }}
+    apiVersion: {{ include "cluster.controlPlane.apiVersion" . }}
+    name: {{ .Values.cluster.name }}

--- a/bootstrap/helm/cluster-api-cluster/templates/gcp/_helpers.tpl
+++ b/bootstrap/helm/cluster-api-cluster/templates/gcp/_helpers.tpl
@@ -1,0 +1,73 @@
+{{/*
+Function to template an GCPManagedMachinePool resource.
+Params:
+  ctx = . context
+  name = the name of the GCPManagedMachinePool resource
+  defaultVals = the default values for the GCPManagedMachinePool resource
+  values = the values for this specific GCPManagedMachinePool resource
+  availabilityZones = the availability zones for the GCPManagedMachinePool
+*/}}
+{{- define "workers.gcp.managedMachinePool" -}}
+{{- $scaling := (.values.spec | default dict).scaling | default .defaultVals.spec.scaling }}
+{{- if $scaling }}
+{{- if not (and (hasKey $scaling "minCount") (hasKey $scaling "maxCount")) }}
+  {{- fail (printf "Invalid value for scaling. Both minCount and maxCount must be set") }}
+{{- end }}
+{{- end }}
+{{- $management := (.values.spec | default dict).management | default .defaultVals.spec.management }}
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: GCPManagedMachinePool
+metadata:
+  name: {{ .name }}
+  annotations:
+    helm.sh/resource-policy: keep
+    {{- if (hasKey .values "annotations") -}}
+    {{- toYaml (merge .values.annotations .defaultVals.annotations)| nindent 4 }}
+    {{- else -}}
+    {{- toYaml .defaultVals.annotations | nindent 4 }}
+    {{- end }}
+  labels:
+    {{- if (hasKey .values "labels") -}}
+    {{- toYaml (merge .values.labels .defaultVals.labels)| nindent 4 }}
+    {{- else -}}
+    {{- toYaml .defaultVals.labels | nindent 4 }}
+    {{- end }}
+spec:
+  nodePoolName: {{ .name }}
+  {{- if $scaling }}
+  scaling:
+    {{- toYaml $scaling | nindent 4 }}
+  {{- end }}
+  {{- if $management }}
+  management:
+    {{- toYaml $management | nindent 4 }}
+  {{- end }}
+  kubernetesLabels:
+    {{- if (dig "spec" "kubernetesLabels" .values) }}
+    {{- toYaml (merge .values.spec.kubernetesLabels .defaultVals.spec.kubernetesLabels) | nindent 4 }}
+    {{- else }}
+    {{- toYaml .defaultVals.spec.kubernetesLabels | nindent 4 }}
+    {{- end }}
+  {{- if or (.defaultVals.spec.kubernetesTaints) ((.values.spec | default dict).kubernetesTaints) }}
+  kubernetesTaints:
+  {{- toYaml ((.values.spec | default dict).kubernetesTaints | default .defaultVals.spec.kubernetesTaints) | nindent 4 }}
+  {{- end }}
+  additionalLabels:
+    {{- if (dig "spec" "additionalLabels" .values) }}
+    {{- toYaml (merge .values.spec.additionalLabels .defaultVals.spec.additionalLabels) | nindent 4 }}
+    {{- else }}
+    {{- toYaml .defaultVals.spec.additionalLabels | nindent 4 }}
+    {{- end }}
+  {{- if .values.spec.providerIDList }}
+  providerIDList:
+  {{- toYaml .values.spec.providerIDList | nindent 2 }}
+  {{- end }}
+  machineType: {{ (.values.spec | default dict).machineType | default .defaultVals.spec.machineType }}
+  diskSizeGb: {{ (.values.spec | default dict).diskSizeGb | default .defaultVals.spec.diskSizeGb }}
+  diskType: {{ (.values.spec | default dict).diskType | default .defaultVals.spec.diskType }}
+  spot: {{ (.values.spec | default dict).spot | default .defaultVals.spec.spot }}
+  preemptible: {{ (.values.spec | default dict).preemptible | default .defaultVals.spec.preemptible }}
+  imageType: {{ (.values.spec | default dict).imageType | default .defaultVals.spec.imageType }}
+---
+{{- include "workers.machinePool" (dict "ctx" .ctx "name" .name "values" .values "defaultVals" .defaultVals) }}
+{{- end }}

--- a/bootstrap/helm/cluster-api-cluster/templates/gcp/cluster.yaml
+++ b/bootstrap/helm/cluster-api-cluster/templates/gcp/cluster.yaml
@@ -1,0 +1,42 @@
+{{- if and (eq .Values.provider "gcp") (eq .Values.type "managed") -}}
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: GCPManagedCluster
+metadata:
+  name: {{ .Values.cluster.name }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  project: {{ .Values.cluster.gcp.project }}
+  region: {{ .Values.cluster.gcp.region }}
+  {{- with .Values.cluster.gcp.additionalLabels }}
+  additionalLabels:
+  {{- . | toYaml | nindent 4 }}
+  {{- end }}
+  controlPlaneEndpoint:
+    host: ""
+    port: 0
+  {{- with .Values.cluster.gcp.addonsConfig }}
+  addonsConfig:
+  {{- . | toYaml | nindent 4 }}
+  {{- end }}
+  network:
+    {{- with .Values.cluster.gcp.network }}
+    name: {{ .name }}
+    autoCreateSubnetworks: {{ .autoCreateSubnetworks }}
+    datapathProvider: {{ .datapathProvider }}
+    {{- end }}
+    subnets:
+      {{- range .Values.cluster.gcp.subnets }}
+      - name: {{ .name }}
+        region: {{ $.Values.cluster.gcp.region }}
+        cidrBlock: {{ .cidrBlock }}
+        description: {{ .description }}
+        {{- with .secondaryCidrBlocks }}
+        secondaryCidrBlocks:
+        {{- . | toYaml | nindent 10 }}
+        {{- end }}
+        privateGoogleAccess: {{ .privateGoogleAccess }}
+        enableFlowLogs: {{ .enableFlowLogs }}
+        purpose: {{ .purpose }}
+      {{- end }}
+{{- end }}

--- a/bootstrap/helm/cluster-api-cluster/templates/gcp/control-plane.yaml
+++ b/bootstrap/helm/cluster-api-cluster/templates/gcp/control-plane.yaml
@@ -1,0 +1,23 @@
+{{- if and (eq .Values.provider "gcp") (eq .Values.type "managed") -}}
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: GCPManagedControlPlane
+metadata:
+  name: {{ .Values.cluster.name }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  clusterName: {{ .Values.cluster.name }}
+  {{- with .Values.cluster.gcp }}
+  project: {{ .project }}
+  location: {{ .region }}
+  enableAutopilot: {{ .enableAutopilot | default false }}
+  enableWorkloadIdentity: {{ .enableWorkloadIdentity }}
+  {{- if ne .releaseChannel "unspecified" }}
+  releaseChannel: {{ .releaseChannel }}
+  {{- end }}
+  endpoint:
+    host: ""
+    port: 0
+  {{- end }}
+  controlPlaneVersion: {{ include "cluster.kubernetesVersion" . | quote }}
+{{- end }}

--- a/bootstrap/helm/cluster-api-cluster/templates/gcp/machinepools.yaml
+++ b/bootstrap/helm/cluster-api-cluster/templates/gcp/machinepools.yaml
@@ -1,0 +1,25 @@
+{{- if and (eq .Values.provider "gcp") (eq .Values.type "managed") -}}
+{{- $currentScope := . -}}
+{{- $defaultVals := .Values.workers.defaults.gcp -}}
+{{- range $name, $values := .Values.workers.gcp }}
+{{- with $currentScope}}
+{{- $isMultiAZ := ($values | default dict).isMultiAZ | default $defaultVals.isMultiAZ }}
+{{- if not $isMultiAZ }}
+  {{- fail (printf "Invalid value for isMultiAZ. GCP currently only supports `true` for this value") }}
+{{- end }}
+{{- $availabilityZones := ($values.spec | default dict).availabilityZones | default $defaultVals.spec.availabilityZones }}
+{{- if and (not $isMultiAZ) (not $availabilityZones) }}
+  {{- fail (printf "Invalid value for isMultiAZ. availabilityZones must be set") }}
+{{- end }}
+{{- if not $isMultiAZ }}
+{{ range $az := $availabilityZones }}
+{{- include "workers.gcp.managedMachinePool" (dict "ctx" $currentScope "name" (printf "%s-%s" $name $az) "defaultVals" $defaultVals "values" $values "availabilityZones" (list $az)) }}
+---
+{{- end }}
+{{- else }}
+{{- include "workers.gcp.managedMachinePool" (dict "ctx" $currentScope "name" $name "defaultVals" $defaultVals "values" $values "availabilityZones" $availabilityZones) }}
+---
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/bootstrap/helm/cluster-api-cluster/templates/kind/cluster.yaml
+++ b/bootstrap/helm/cluster-api-cluster/templates/kind/cluster.yaml
@@ -1,0 +1,9 @@
+{{- if and (eq .Values.provider "kind") (eq .Values.type "managed") -}}
+kind: DockerCluster
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+metadata:
+  name: {{ .Values.cluster.name }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec: {}
+{{- end }}

--- a/bootstrap/helm/cluster-api-cluster/templates/kind/control-plane.yaml
+++ b/bootstrap/helm/cluster-api-cluster/templates/kind/control-plane.yaml
@@ -1,0 +1,45 @@
+{{- if and (eq .Values.provider "kind") (eq .Values.type "managed") -}}
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: {{ .Values.cluster.name }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  replicas: 1
+  version: {{ include "cluster.kubernetesVersion" . }}
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: DockerMachineTemplate
+      name: controlplane
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+        certSANs:
+          - localhost
+          - 127.0.0.1
+          - 0.0.0.0
+      controllerManager:
+        extraArgs:
+          enable-hostpath-provisioner: "true"
+    initConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+    joinConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerMachineTemplate
+metadata:
+  name: controlplane
+spec:
+  template:
+    spec:
+      extraMounts:
+        - containerPath: /var/run/docker.sock
+          hostPath: /var/run/docker.sock
+{{- end }}

--- a/bootstrap/helm/cluster-api-cluster/templates/kind/kubeadm-config.yaml
+++ b/bootstrap/helm/cluster-api-cluster/templates/kind/kubeadm-config.yaml
@@ -1,0 +1,13 @@
+{{- if and (eq .Values.provider "kind") (eq .Values.type "managed") -}}
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfig
+metadata:
+  name: worker-mp-config
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  joinConfiguration:
+    nodeRegistration:
+      kubeletExtraArgs:
+        eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+{{- end }}

--- a/bootstrap/helm/cluster-api-cluster/templates/kind/machine-pools.yaml
+++ b/bootstrap/helm/cluster-api-cluster/templates/kind/machine-pools.yaml
@@ -1,0 +1,24 @@
+{{- if and (eq .Values.provider "kind") (eq .Values.type "managed") -}}
+
+{{- $currentScope := . -}}
+{{- $defaultVals := .Values.workers.defaults.kind -}}
+
+{{- range $name, $values := .Values.workers.kind }}
+{{- with $currentScope}}
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerMachinePool
+metadata:
+  name: {{ $name }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  template:
+      extraMounts:
+        - containerPath: /var/run/docker.sock
+          hostPath: /var/run/docker.sock
+---
+{{- include "workers.machinePool" (dict "ctx" $currentScope "name" $name "values" $values "defaultVals" $defaultVals) }}
+{{- end }}
+---
+{{ end }}
+{{- end }}

--- a/bootstrap/helm/cluster-api-cluster/tests/aws_cluster_test.yaml
+++ b/bootstrap/helm/cluster-api-cluster/tests/aws_cluster_test.yaml
@@ -1,0 +1,23 @@
+suite: test aws cluster
+templates:
+  - aws/cluster.yaml
+tests:
+  - it: should be created with the controlPlaneEndpoint
+    set:
+      cluster.name: test
+      provider: aws
+      type: managed
+      cluster.aws.controlPlaneEndpoint: abc
+    asserts:
+      - template: aws/cluster.yaml
+        hasDocuments:
+          count: 1
+      - template: aws/cluster.yaml
+        documentIndex: 0
+        isKind:
+          of: AWSManagedCluster
+      - template: aws/cluster.yaml
+        documentIndex: 0
+        equal:
+          path: spec.controlPlaneEndpoint
+          value: abc

--- a/bootstrap/helm/cluster-api-cluster/tests/aws_control_plane_test.yaml
+++ b/bootstrap/helm/cluster-api-cluster/tests/aws_control_plane_test.yaml
@@ -1,0 +1,43 @@
+suite: test control plane
+templates:
+  - aws/control-plane.yaml
+tests:
+  - it: check kind
+    set:
+      cluster.name: test
+      provider: aws
+      type: managed
+      cluster.aws.controlPlaneEndpoint: abc
+    asserts:
+      - template: aws/control-plane.yaml
+        hasDocuments:
+          count: 1
+      - template: aws/control-plane.yaml
+        documentIndex: 0
+        isKind:
+          of: AWSManagedControlPlane
+  - it: should equal
+    set:
+      cluster.name: test
+      provider: aws
+      type: managed
+      cluster.aws.region: abc
+      cluster.kubernetesVersion: v1.2.3
+    asserts:
+      - equal:
+          path: spec.region
+          value: abc
+      - equal:
+          path: spec.sshKeyName
+          value: default
+      - equal:
+          path: spec.version
+          value: v1.2.3
+      - equal:
+          path: spec.eksClusterName
+          value: test
+      - equal:
+          path: spec.eksClusterName
+          value: test
+        template: aws/control-plane.yaml
+        documentIndex: 0

--- a/bootstrap/helm/cluster-api-cluster/tests/aws_machinepools_test.yaml
+++ b/bootstrap/helm/cluster-api-cluster/tests/aws_machinepools_test.yaml
@@ -1,0 +1,156 @@
+suite: test machine pools
+templates:
+  - aws/machinepools.yaml
+tests:
+  - it: check kind
+    set:
+      cluster.name: test
+      provider: aws
+      type: managed
+      workers.defaults.aws.spec.availabilityZones:
+      - us-east-1a
+      - us-east-1b
+      - us-east-1c
+    asserts:
+      - template: aws/machinepools.yaml
+        hasDocuments:
+          count: 24
+      - template: aws/machinepools.yaml
+        documentIndex: 0
+        isKind:
+          of: AWSManagedMachinePool
+      - template: aws/machinepools.yaml
+        documentIndex: 13
+        isKind:
+          of: MachinePool
+  - it: test defaults
+    set:
+      cluster.name: test
+      provider: aws
+      type: managed
+      cluster.aws.region: abc
+      cluster.kubernetesVersion: v1.2.3
+      workers.defaults.aws.spec.availabilityZones:
+      - us-east-1a
+      - us-east-1b
+      - us-east-1c
+    asserts:
+      - equal:
+          path: spec.amiType
+          value: AL2_x86_64
+        documentIndex: 0
+      - equal:
+          path: spec.diskSize
+          value: 50
+        documentIndex: 2
+    template: aws/machinepools.yaml
+  - it: test large-burst-spot
+    set:
+      cluster.name: test
+      provider: aws
+      type: managed
+      cluster.aws.region: abc
+      cluster.kubernetesVersion: v1.2.3
+      workers.defaults.aws.spec.availabilityZones:
+      - us-east-1a
+      - us-east-1b
+      - us-east-1c
+    asserts:
+      - equal:
+          path: spec.capacityType
+          value: spot
+      - equal:
+          path: spec.eksNodegroupName
+          value: large-burst-spot
+      - equal:
+          path: spec.instanceType
+          value: t3.2xlarge
+      - equal:
+          path: spec.availabilityZones
+          value:
+          - us-east-1a
+          - us-east-1b
+          - us-east-1c
+    template: aws/machinepools.yaml
+    documentIndex: 6
+  - it: test large-burst-on-demand-us-east-1a
+    set:
+      cluster.name: test
+      provider: aws
+      type: managed
+      cluster.aws.region: abc
+      cluster.kubernetesVersion: v1.2.3
+      workers.defaults.aws.spec.availabilityZones:
+      - us-east-1a
+      - us-east-1b
+      - us-east-1c
+    asserts:
+      - equal:
+          path: spec.capacityType
+          value: onDemand
+      - equal:
+          path: spec.eksNodegroupName
+          value: large-burst-on-demand-us-east-1a
+      - equal:
+          path: spec.instanceType
+          value: t3.2xlarge
+      - equal:
+          path: spec.availabilityZones
+          value:
+          - us-east-1a
+    template: aws/machinepools.yaml
+    documentIndex: 0
+  - it: test large-burst-on-demand-us-east-1b
+    set:
+      cluster.name: test
+      provider: aws
+      type: managed
+      cluster.aws.region: abc
+      cluster.kubernetesVersion: v1.2.3
+      workers.defaults.aws.spec.availabilityZones:
+      - us-east-1a
+      - us-east-1b
+      - us-east-1c
+    asserts:
+      - equal:
+          path: spec.capacityType
+          value: onDemand
+      - equal:
+          path: spec.eksNodegroupName
+          value: large-burst-on-demand-us-east-1b
+      - equal:
+          path: spec.instanceType
+          value: t3.2xlarge
+      - equal:
+          path: spec.availabilityZones
+          value:
+          - us-east-1b
+    template: aws/machinepools.yaml
+    documentIndex: 2
+  - it: test large-burst-on-demand-us-east-1c
+    set:
+      cluster.name: test
+      provider: aws
+      type: managed
+      cluster.aws.region: abc
+      cluster.kubernetesVersion: v1.2.3
+      workers.defaults.aws.spec.availabilityZones:
+      - us-east-1a
+      - us-east-1b
+      - us-east-1c
+    asserts:
+      - equal:
+          path: spec.capacityType
+          value: onDemand
+      - equal:
+          path: spec.eksNodegroupName
+          value: large-burst-on-demand-us-east-1c
+      - equal:
+          path: spec.instanceType
+          value: t3.2xlarge
+      - equal:
+          path: spec.availabilityZones
+          value:
+          - us-east-1c
+    template: aws/machinepools.yaml
+    documentIndex: 4

--- a/bootstrap/helm/cluster-api-cluster/tests/azure_cluster_identity_test.yaml
+++ b/bootstrap/helm/cluster-api-cluster/tests/azure_cluster_identity_test.yaml
@@ -1,0 +1,101 @@
+suite: test azure cluster identity
+templates:
+  - azure/bootstrap-cluster-identity.yaml
+  - azure/cluster-workload-identity.yaml
+  - azure/control-plane.yaml
+tests:
+  - it: should be created if bootstrapMode is true
+    set:
+      cluster.name: test
+      provider: azure
+      type: managed
+      cluster.azure.clusterIdentity.tenantID: tenant-id
+      cluster.azure.clusterIdentity.bootstrapCredentials.clientID: client-id
+      cluster.azure.clusterIdentity.bootstrapCredentials.clientSecret: client-secret
+      cluster.azure.clusterIdentity.bootstrapMode: true
+    asserts:
+      - template: azure/bootstrap-cluster-identity.yaml
+        hasDocuments:
+          count: 4
+      - template: azure/bootstrap-cluster-identity.yaml
+        documentIndex: 0
+        isKind:
+          of: AzureClusterIdentity
+      - template: azure/bootstrap-cluster-identity.yaml
+        documentIndex: 0
+        matchRegex:
+          path: metadata.name
+          pattern: -azure-bootstrap-identity$
+      - template: azure/bootstrap-cluster-identity.yaml
+        documentIndex: 0
+        equal:
+          path: spec.tenantID
+          value: tenant-id
+      - template: azure/bootstrap-cluster-identity.yaml
+        documentIndex: 0
+        equal:
+          path: spec.clientID
+          value: client-id
+      - template: azure/bootstrap-cluster-identity.yaml
+        documentIndex: 1
+        equal:
+          path: data.clientSecret
+          value: client-secret
+          decodeBase64: true
+      - template: azure/bootstrap-cluster-identity.yaml
+        documentIndex: 2
+        equal:
+          path: spec.clientID
+          value: client-id
+      - template: azure/bootstrap-cluster-identity.yaml
+        documentIndex: 2
+        equal:
+          path: spec.tenantID
+          value: tenant-id
+      - template: azure/bootstrap-cluster-identity.yaml
+        documentIndex: 3
+        matchRegex:
+          path: spec.azureIdentity
+          pattern: test-NAMESPACE-RELEASE-NAME-azure-bootstrap-identity$
+      - template: azure/cluster-workload-identity.yaml
+        hasDocuments:
+          count: 0
+      - template: azure/control-plane.yaml
+        hasDocuments:
+          count: 1
+      - template: azure/control-plane.yaml
+        documentIndex: 0
+        matchRegex:
+          path: spec.identityRef.name
+          pattern: -azure-bootstrap-identity$
+  - it: should not be created if bootstrapMode is false
+    set:
+      cluster.name: test
+      provider: azure
+      type: managed
+      cluster.azure.clusterIdentity.tenantID: tenant-id
+      cluster.azure.clusterIdentity.workloadIdentity.name: default
+      cluster.azure.clusterIdentity.workloadIdentity.clientID: client-id
+      cluster.azure.clusterIdentity.bootstrapMode: false
+    asserts:
+      - template: azure/bootstrap-cluster-identity.yaml
+        hasDocuments:
+          count: 0
+      - template: azure/cluster-workload-identity.yaml
+        hasDocuments:
+          count: 1
+      - template: azure/cluster-workload-identity.yaml
+        documentIndex: 0
+        equal:
+          path: spec.clientID
+          value: client-id
+      - template: azure/cluster-workload-identity.yaml
+        documentIndex: 0
+        equal:
+          path: spec.tenantID
+          value: tenant-id
+      - template: azure/control-plane.yaml
+        documentIndex: 0
+        equal:
+          path: spec.identityRef.name
+          value: default

--- a/bootstrap/helm/cluster-api-cluster/values.yaml
+++ b/bootstrap/helm/cluster-api-cluster/values.yaml
@@ -1,0 +1,699 @@
+provider: "" # Can be aws, gcp, azure or kind
+## managed or unmanaged, currently only managed is supported
+type: managed
+
+cluster:
+  ## The name of the cluster
+  name: plural
+  ## The version of Kubernetes to deploy
+  kubernetesVersion: ""
+  ## The cidr blocks for pods
+  podCidrBlocks:
+    - 192.168.0.0/16 # TODO: shouldn't this also be getting propagated to things like what `.Values.cluster.aws.network.vpc.cidrBlock` is setting?
+  ## The cidr blocks for services
+  serviceCidrBlocks: [] # TODO: check if we should be setting this
+
+  ##################################
+  ###         AWS CLUSTER        ###
+  ##################################
+  aws:
+    ## The region to deploy the cluster to
+    region: ""
+    ## The name of the ssh key to use for the cluster
+    sshKeyName: default
+    ## The cluster addons to deploy
+    addons:
+      - conflictResolution: overwrite
+        name: kube-proxy
+        version: v1.24.15-eksbuild.2
+      - conflictResolution: overwrite
+        name: vpc-cni
+        version: v1.13.4-eksbuild.1
+      - conflictResolution: overwrite
+        name: coredns
+        version: v1.9.3-eksbuild.6
+
+    network:
+      # vpc:
+      #   id: ""
+      #   cidrBlock: ""
+      #   # ipv6: # NOTE: setting `ipv6: {}` will enable ipv6 and auto generate the cidr block. Needed for migration.
+      #   #   cidrBlock: ""
+      #   #   poolId: ""
+      #   #   egressOnlyInternetGatewayId: ""
+      #   internetGatewayId: ""
+      #   tags: {}
+      #   availabilityZoneUsageLimit: 3 # TODO: is set to 3 by default
+      #   availabilityZoneSelection: Ordered # TODO: How do we deal with people choosing ones manually in the init flow now? Should we only allow number input and always use ordered for the time being? Set by default to Ordered. Can be Ordered or Random
+      # subnets: []
+      # # - id: ""
+      # #   cidrBlock: ""
+      # #   ipv6CidrBlock: ""
+      # #   availabilityZone: ""
+      # #   isPublic: false
+      # #   isIpv6: false
+      # #   routeTableId: ""
+      # #   natGatewayId: ""
+      # #   tags: {}
+      # cni:
+      #   cniIngressRules: []
+      #   # - description: ""
+      #   #   fromPort: 0
+      #   #   toPort: 0
+      #   #   protocol: "" # TODO: find valid values. Can be tcp.
+      # securityGroupOverrides: {}
+    identityRef: {}
+    secondaryCidrBlock: ""
+    partition: ""
+    roleName: ""
+    roleAdditionalPolicies: []
+    logging:
+      apiServer: false
+      audit: false
+      authenticator: false
+      controllerManager: false
+      scheduler: false
+    encryptionConfig:
+      provider: ""
+      resources: []
+    additionalTags: {}
+    iamAuthenticatorConfig:
+      mapRoles: []
+      # - rolearn: ""
+      #   username: ""
+      #   groups: []
+      mapUsers: []
+      # - userarn: ""
+      #   username: ""
+      #   groups: []
+    endpointAccess:
+      public: true
+      publicCIDRs: []
+      private: false
+    bastion:
+      enabled: false
+      disableIngressRules: false
+      allowedCIDRBlocks: []
+      instanceType: ""
+      ami: ""
+    tokenMethod: "" # iam-authenticator
+    associateOIDCProvider: true
+    oidcIdentityProviderConfig: {}
+      # clientId: ""
+      # groupsClaim: ""
+      # groupsPrefix: ""
+      # identityProviderConfigName: ""
+      # issuerUrl: ""
+      # requiredClaims: {}
+      # usernameClaim: ""
+      # usernamePrefix: ""
+      # tags: {}
+    vpcCni:
+      disable: false
+      env: []
+      # - name: ""
+      #   value: ""
+    kubeProxy:
+      disable: false
+
+  ###################################
+  ###        AZURE CLUSTER        ###
+  ###################################
+  azure:
+    clusterIdentity:
+      bootstrapMode: false
+      # Credentials for the cluster identity used to bootstrap cluster.
+      bootstrapCredentials:
+        # Service Principal client ID used during bootstrapping.
+        clientID: ""
+        # Service Principal password used during bootstrapping.
+        clientSecret: ""
+      # Settings for the workload identity used by the cluster after bootstrapping.
+      workloadIdentity:
+        # If the default AzureClusterIdentity should be created.
+        enabled: true
+        # Name of AzureClusterIdentity to be used when reconciling this cluster.
+        name: default
+        # Service Principal or User Assigned MSI Client ID.
+        clientID: ""
+        # Used to identify the namespaces the clusters are allowed to use the identity from.
+        # Namespaces can be selected either using an array of namespaces or with label selector.
+        # An empty allowedNamespaces object indicates that AzureClusters can use this identity from any namespace.
+        # If this object is nil, no namespaces will be allowed (default behaviour, if this field is not provided)
+        # A namespace should be either in the NamespaceList or match with Selector to use the identity.
+        # Make sure that the namespace this cluster is deployed in is allowed.
+        allowedNamespaces: {}
+      # Primary tenant ID for the cluster Identity.
+      tenantID: ""
+      # Name of AzureClusterIdentity to be used when reconciling this cluster.
+      # This field is only used when workloadIdentity is disabled and not used during cluster bootstrapping.
+      name: ""
+    # GUID of the Azure subscription to hold this cluster.
+    subscriptionID: ""
+    # String matching one of the canonical Azure region names.
+    # Examples: westus2, eastus.
+    location: ""
+    # Name of the Azure resource group for this AKS Cluster.
+    resourceGroupName: ""
+    # Name of the resource group containing cluster IaaS resources.
+    nodeResourceGroupName: ""
+    # Describes the vnet for the AKS cluster. Will be created if it does not exist.
+    virtualNetwork:
+      cidrBlock: 10.1.0.0/16
+      name: ""
+      subnet:
+        cidrBlock: 10.1.0.0/18
+        name: plural-subnet
+    # Network plugin used for building Kubernetes network.
+    # One of: azure, kubenet.
+    networkPlugin: azure
+    # Network policy used for building Kubernetes network.
+    # One of: azure, calico.
+    networkPolicy: azure
+    # Outbound configuration used by Nodes.
+    # One of: loadBalancer, managedNATGateway, userAssignedNATGateway, userDefinedRouting.
+    outboundType: ""
+    # String literal containing an SSH public key base64 encoded.
+    # Use empty value "" to autogenerate new key. Use "skip" value to not set the key.
+    sshPublicKey: ""
+    # DNSServiceIP is an IP address assigned to the Kubernetes DNS service.
+    # It must be within the Kubernetes service address range specified in serviceCidr.
+    dnsServiceIP: ""
+    # Identity configuration used by the AKS control plane.
+    identity:
+      # The identity type to use.
+      # One of: SystemAssigned, UserAssigned.
+      type: SystemAssigned
+    # SKU of the AKS to be provisioned.
+    sku:
+      tier: Paid
+    # SKU of the loadBalancer to be provisioned.
+    # One of: Basic, Standard.
+    loadBalancerSKU: Standard
+    # Azure Active Directory configuration to integrate with AKS for AAD authentication.
+    aadProfile: {}
+    # Profile of the cluster load balancer.
+    loadBalancerProfile: {}
+    # Access profile for AKS API server.
+    apiServerAccessProfile: {}
+    # Parameters to be applied to the cluster-autoscaler when enabled.
+    autoscalerProfile:
+      # Default is false. Changed to true as in old bootstrap.
+      balanceSimilarNodeGroups: "true"
+      # One of: least-waste, most-pods, priority, random.
+      expander: random
+      maxEmptyBulkDelete: "10"
+      maxGracefulTerminationSec: "600"
+      maxNodeProvisionTime: 15m
+      maxTotalUnreadyPercentage: "45"
+      newPodScaleUpDelay: 0s
+      okTotalUnreadyCount: "3"
+      scanInterval: 10s
+      scaleDownDelayAfterAdd: 10m
+      scaleDownDelayAfterDelete: 10s
+      scaleDownDelayAfterFailure: 3m
+      scaleDownUnneededTime: 10m
+      scaleDownUnreadyTime: 20m
+      # Default is 0.5. Changed to 0.7 as in old bootstrap.
+      scaleDownUtilizationThreshold: "0.7"
+      skipNodesWithLocalStorage: "false"
+      skipNodesWithSystemPods: "true"
+    # Profiles of managed cluster add-on.
+    addonProfiles: []
+
+  ###################################
+  ###         GCP CLUSTER         ###
+  ###################################
+  gcp:
+    # Project is the id of the project to deploy the cluster to.
+    project: ""
+    # Region represents the location (region or zone) in which the GKE cluster will be created.
+    # Examples: "europe-central2" TODO: add more examples
+    region: ""
+    # AdditionalLabels is an optional set of tags to add to GCP resources managed by the GCP provider,
+    # in addition to the ones added by default.
+    additionalLabels:
+      managed-by: plural
+    # EnableAutopilot indicates whether to enable autopilot for this GKE cluster.
+    #
+    # Note: Autopilot enabled clusters are not supported at this time.
+    enableAutopilot: false
+    # EnableWorkloadIdentity allows enabling workload identity during cluster creation when
+    # EnableAutopilot is disabled. It allows workloads in your GKE clusters to impersonate
+    # Identity and Access Management (IAM) service accounts to access Google Cloud services.
+    # Ref: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
+    enableWorkloadIdentity: true
+    # ReleaseChannel is the release channel of the GKE cluster
+    # One of: unspecified, rapid, regular, stable
+    releaseChannel: unspecified
+    # AddonsConfig is a configuration for the addons that can be automatically spun up in the
+    # cluster, enabling additional functionality.
+    addonsConfig:
+      # HttpLoadBalancingEnabled tracks whether the HTTP Load Balancing controller is enabled in the cluster.
+      # When enabled, it runs a small pod in the cluster that manages the load balancers.
+      httpLoadBalancingEnabled: true
+      # HorizontalPodAutoscalingEnabled tracks whether the Horizontal Pod Autoscaling feature is enabled in the cluster.
+      # When enabled, it ensures that metrics are collected into Stackdriver Monitoring.
+      horizontalPodAutoscalingEnabled: true
+      # NetworkPolicyEnabled tracks whether the addon is enabled or not on the Master,
+      # it does not track whether network policy is enabled for the nodes.
+      networkPolicyEnabled: false
+      # GcpFilestoreCsiDriverEnabled tracks whether the GCP Filestore CSI driver is enabled for this cluster.
+      gcpFilestoreCsiDriverEnabled: true
+    # Network encapsulates all things related to the GCP network.
+    network:
+      name: ""
+      # AutoCreateSubnetworks: When set to true, the VPC network is created
+      # in "auto" mode. When set to false, the VPC network is created in
+      # "custom" mode.
+      #
+      # An auto mode VPC network starts with one subnet per region. Each
+      # subnet has a predetermined range as described in Auto mode VPC
+      # network IP ranges.
+      #
+      # Note: Only auto mode is supported at this time.
+      autoCreateSubnetworks: true
+      # The desired datapath provider for this cluster.
+      # One of:
+      # - UNSPECIFIED - default value
+      # - LEGACY_DATAPATH - uses the IPTables implementation based on kube-proxy
+      # - ADVANCED_DATAPATH - uses the eBPF based GKE Dataplane V2 with additional features
+      datapathProvider: ADVANCED_DATAPATH
+    subnets:
+      - name: plural-subnetwork
+        # CidrBlock is the range of internal addresses that are owned by this
+        # subnetwork. Provide this property when you create the subnetwork. For
+        # example, 10.0.0.0/8 or 192.168.0.0/16. Ranges must be unique and
+        # non-overlapping within a network. Only IPv4 is supported. This field
+        # can be set only at resource creation time.
+        cidrBlock: 10.0.32.0/20
+        # Description is an optional description associated with the resource.
+        description: ""
+        # SecondaryCidrBlocks defines secondary CIDR ranges,
+        # from which secondary IP ranges of a VM may be allocated
+        secondaryCidrBlocks: {}
+        # PrivateGoogleAccess defines whether VMs in this subnet can access
+        # Google services without assigning external IP addresses
+        privateGoogleAccess: true
+        # EnableFlowLogs: Whether to enable flow logging for this subnetwork.
+        # If this field is not explicitly set, it will not appear in get
+        # listings. If not set the default behavior is to disable flow logging.
+        enableFlowLogs: false
+        # Purpose: The purpose of the resource.
+        # If unspecified, the purpose defaults to PRIVATE_RFC_1918.
+        # The enableFlowLogs field isn't supported with the purpose field set to INTERNAL_HTTPS_LOAD_BALANCER.
+        # One of:
+        # - INTERNAL_HTTPS_LOAD_BALANCER - Subnet reserved for Internal HTTP(S) Load Balancing.
+        # - PRIVATE - Regular user created or automatically created subnet.
+        # - PRIVATE_RFC_1918 - Regular user created or automatically created subnet.
+        # - PRIVATE_SERVICE_CONNECT - Subnetworks created for Private Service Connect in the producer network.
+        # - REGIONAL_MANAGED_PROXY - Subnetwork used for Regional Internal/External HTTP(S) Load Balancing.
+        purpose: PRIVATE_RFC_1918
+
+workers:
+  defaults:
+    #########################################
+    ###        AWS WORKER DEFAULTS        ###
+    #########################################
+    aws:
+      replicas: 0
+      labels: {}
+      annotations:
+        cluster.x-k8s.io/replicas-managed-by: external-autoscaler
+      isMultiAZ: false # if false, will create a node group per AZ
+      spec:
+        amiType: AL2_x86_64 # AL2_x86_64, AL2_x86_64_GPU, AL2_ARM_64
+        amiVersion: ""
+        capacityType: onDemand # onDemand, spot
+        diskSize: 50
+        instanceType: t3a.large
+        roleName: ""
+        scaling:
+          maxSize: 5
+          minSize: 1
+        availabilityZones: []
+        subnetIDs: []
+        labels: {}
+        taints: {}
+        updateConfig:
+          maxUnavailable: 1
+          # maxSurge: 1
+        additionalTags: {}
+        roleAdditionalPolicies: []
+    #########################################
+    ###       AZURE WORKER DEFAULTS       ###
+    #########################################
+    azure:
+      replicas: 0
+      labels: {}
+      annotations:
+        cluster.x-k8s.io/replicas-managed-by: external-autoscaler
+      isMultiAZ: false # if false, will create a node group per AZ
+      spec:
+        availabilityZones:
+        - "1"
+        - "2"
+        - "3"
+        enableNodePublicIP: false
+        maxPods: 110
+        mode: User
+        nodeLabels: {}
+        nodePublicIPPrefixID: ""
+        osDiskSizeGB: 50
+        osDiskType: Managed
+        osType: Linux
+        scaling:
+          maxSize: 5
+          minSize: 1
+        sku: Standard_D2s_v3
+        additionalTags: {}
+        taints: {}
+        kubeletConfig: {}
+        linuxOSConfig: {}
+    #########################################
+    ###        GCP WORKER DEFAULTS        ###
+    #########################################
+    gcp:
+      replicas: 0
+      labels: {}
+      annotations:
+        cluster.x-k8s.io/replicas-managed-by: external-autoscaler
+      isMultiAZ: false # if false, will create a node group per AZ # TODO: false currently unsupported so all node groups set this to true
+      spec:
+        scaling:
+          maxCount: 9
+          minCount: 1
+        management:
+          autoRepair: true
+          autoUpgrade: true
+        kubernetesLabels:
+          plural.sh/capacityType: ON_DEMAND
+          plural.sh/performanceType: BURST
+        kubernetesTaints: []
+        additionalLabels: {}
+        providerIDList: []
+        machineType: e2-standard-2
+        diskSizeGb: 50
+        diskType: pd-standard
+        spot: false
+        preemptible: false
+        imageType: COS_CONTAINERD
+    #########################################
+    ###        Docker WORKER DEFAULTS     ###
+    #########################################
+    kind:
+      replicas: 0
+  #################################
+  ###        AWS WORKERS        ###
+  #################################
+  aws:
+    small-burst-spot:
+      isMultiAZ: true
+      spec:
+        labels:
+          plural.sh/capacityType: SPOT
+          plural.sh/performanceType: BURST
+          plural.sh/scalingGroup: small-burst-spot
+        additionalTags: { } # TODO: allow this to not be set
+        capacityType: spot
+        scaling:
+          maxSize: 27
+          minSize: 0
+        taints:
+          - effect: no-schedule
+            key: plural.sh/capacityType
+            value: SPOT
+        updateConfig:
+          maxUnavailable: 1
+    medium-burst-spot:
+      isMultiAZ: true
+      spec:
+        labels:
+          plural.sh/capacityType: SPOT
+          plural.sh/performanceType: BURST
+          plural.sh/scalingGroup: medium-burst-spot
+        additionalTags: { } # TODO: allow this to not be set
+        capacityType: spot
+        instanceType: t3.xlarge
+        scaling:
+          maxSize: 27
+          minSize: 0
+        taints:
+          - effect: no-schedule
+            key: plural.sh/capacityType
+            value: SPOT
+    large-burst-spot:
+      isMultiAZ: true
+      spec:
+        labels:
+          plural.sh/capacityType: SPOT
+          plural.sh/performanceType: BURST
+          plural.sh/scalingGroup: large-burst-spot
+        additionalTags: { } # TODO: allow this to not be set
+        instanceType: t3.2xlarge
+        capacityType: spot
+        scaling:
+          maxSize: 27
+          minSize: 0
+        taints:
+          - effect: no-schedule
+            key: plural.sh/capacityType
+            value: SPOT
+    small-burst-on-demand:
+      replicas: 1
+      spec:
+        labels:
+          plural.sh/capacityType: ON_DEMAND
+          plural.sh/performanceType: BURST
+          plural.sh/scalingGroup: small-burst-on-demand
+        additionalTags: { } # TODO: allow this to not be set
+        scaling:
+          maxSize: 1
+          minSize: 1
+        updateConfig:
+          maxUnavailable: 1
+    medium-burst-on-demand:
+      spec:
+        labels:
+          plural.sh/capacityType: ON_DEMAND
+          plural.sh/performanceType: BURST
+          plural.sh/scalingGroup: medium-burst-on-demand
+        additionalTags: { } # TODO: allow this to not be set
+        instanceType: t3.xlarge
+        scaling:
+          maxSize: 27
+          minSize: 0
+    large-burst-on-demand:
+      spec:
+        labels:
+          plural.sh/capacityType: ON_DEMAND
+          plural.sh/performanceType: BURST
+          plural.sh/scalingGroup: medium-burst-on-demand
+        additionalTags: { } # TODO: allow this to not be set
+        instanceType: t3.2xlarge
+        scaling:
+          maxSize: 27
+          minSize: 0
+  #################################
+  ###       AZURE WORKERS       ###
+  #################################
+  azure:
+    lsod:
+      kubernetesVersion: v1.25.11
+      spec:
+        additionalTags: # TODO: allow this to not be set
+          ScalingGroup: large-sustained-on-demand
+        enableNodePublicIP: false
+        maxPods: 110
+        mode: User
+        nodeLabels:
+          plural.sh/capacityType: ON_DEMAND
+          plural.sh/performanceType: SUSTAINED
+          plural.sh/scalingGroup: large-sustained-on-demand
+        osDiskSizeGB: 50
+        osDiskType: Managed
+        osType: Linux
+        scaling:
+          maxSize: 9
+          minSize: 0
+        sku: Standard_D8as_v5
+    lsspot:
+      replicas: 0
+      isMultiAZ: true
+      kubernetesVersion: v1.25.11
+      spec:
+        additionalTags: # TODO: allow this to not be set
+          ScalingGroup: large-sustained-spot
+        enableNodePublicIP: false
+        maxPods: 110
+        mode: User
+        nodeLabels:
+          plural.sh/capacityType: SPOT
+          plural.sh/performanceType: SUSTAINED
+          plural.sh/scalingGroup: large-sustained-spot
+        osDiskSizeGB: 50
+        osDiskType: Managed
+        osType: Linux
+        scaleSetPriority: Spot
+        scaling:
+          maxSize: 9
+          minSize: 0
+        scaleDownMode: Delete
+        spotMaxPrice: -1
+        sku: Standard_D8as_v5
+        taints:
+          - effect: NoSchedule
+            key: plural.sh/capacityType
+            value: SPOT
+          - effect: NoSchedule
+            key: kubernetes.azure.com/scalesetpriority
+            value: spot
+    msod:
+      kubernetesVersion: v1.25.11
+      spec:
+        additionalTags: # TODO: allow this to not be set
+          ScalingGroup: medium-sustained-on-demand
+        enableNodePublicIP: false
+        maxPods: 110
+        mode: User
+        nodeLabels:
+          plural.sh/capacityType: ON_DEMAND
+          plural.sh/performanceType: SUSTAINED
+          plural.sh/scalingGroup: medium-sustained-on-demand
+        osDiskSizeGB: 50
+        osDiskType: Managed
+        osType: Linux
+        scaling:
+          maxSize: 9
+          minSize: 0
+        sku: Standard_D4as_v5
+    msspot:
+      isMultiAZ: true
+      kubernetesVersion: v1.25.11
+      spec:
+        additionalTags: # TODO: allow this to not be set
+          ScalingGroup: medium-sustained-spot
+        enableNodePublicIP: false
+        maxPods: 110
+        mode: User
+        nodeLabels:
+          plural.sh/capacityType: SPOT
+          plural.sh/performanceType: SUSTAINED
+          plural.sh/scalingGroup: medium-sustained-spot
+        osDiskSizeGB: 50
+        osDiskType: Managed
+        osType: Linux
+        scaleSetPriority: Spot
+        scaling:
+          maxSize: 9
+          minSize: 0
+        scaleDownMode: Delete
+        spotMaxPrice: -1
+        sku: Standard_D4as_v5
+        taints:
+          - effect: NoSchedule
+            key: plural.sh/capacityType
+            value: SPOT
+          - effect: NoSchedule
+            key: kubernetes.azure.com/scalesetpriority
+            value: spot
+    ssod:
+      replicas: 1
+      kubernetesVersion: v1.25.11
+      spec:
+        additionalTags: # TODO: allow this to not be set
+          ScalingGroup: small-sustained-on-demand
+        enableNodePublicIP: false
+        maxPods: 110
+        mode: System
+        nodeLabels:
+          plural.sh/capacityType: ON_DEMAND
+          plural.sh/performanceType: SUSTAINED
+          plural.sh/scalingGroup: small-sustained-on-demand
+        osDiskSizeGB: 50
+        osDiskType: Managed
+        osType: Linux
+        scaling:
+          maxSize: 9
+          minSize: 1
+        sku: Standard_D2as_v5
+    ssspot:
+      isMultiAZ: true
+      kubernetesVersion: v1.25.11
+      spec:
+        additionalTags: # TODO: allow this to not be set
+          ScalingGroup: small-sustained-spot
+        enableNodePublicIP: false
+        maxPods: 110
+        mode: User
+        nodeLabels:
+          plural.sh/capacityType: SPOT
+          plural.sh/performanceType: SUSTAINED
+          plural.sh/scalingGroup: small-sustained-spot
+        osDiskSizeGB: 50
+        osDiskType: Managed
+        osType: Linux
+        scaleSetPriority: Spot
+        scaling:
+          maxSize: 9
+          minSize: 0
+        scaleDownMode: Delete
+        spotMaxPrice: -1
+        sku: Standard_D2as_v5
+        taints:
+          - effect: NoSchedule
+            key: plural.sh/capacityType
+            value: SPOT
+          - effect: NoSchedule
+            key: kubernetes.azure.com/scalesetpriority
+            value: spot
+  #################################
+  ###        GCP WORKERS        ###
+  #################################
+  gcp:
+    small-burst-on-demand:
+      replicas: 3
+      isMultiAZ: true
+      spec:
+        scaling:
+          minCount: 1
+          maxCount: 9
+        management:
+          autoRepair: true
+          autoUpgrade: true
+        kubernetesLabels:
+          plural.sh/scalingGroup: small-burst-on-demand
+        additionalLabels: { } # TODO: allow this to not be set
+        machineType: e2-standard-2
+    medium-burst-on-demand:
+      isMultiAZ: true
+      spec:
+        scaling:
+          minCount: 0
+          maxCount: 9
+        management:
+          autoRepair: true
+          autoUpgrade: true
+        kubernetesLabels:
+          plural.sh/scalingGroup: medium-burst-on-demand
+        additionalLabels: { } # TODO: allow this to not be set
+        machineType: e2-standard-4
+    large-burst-on-demand:
+      isMultiAZ: true
+      spec:
+        scaling:
+          minCount: 0
+          maxCount: 9
+        management:
+          autoRepair: true
+          autoUpgrade: true
+        kubernetesLabels:
+          plural.sh/scalingGroup: large-burst-on-demand
+        additionalLabels: { } # TODO: allow this to not be set
+        machineType: e2-standard-8
+  #################################
+  ###        Docker WORKERS     ###
+  #################################
+  kind:
+    small-burst-0:
+      replicas: 2

--- a/bootstrap/helm/cluster-api-cluster/values.yaml.tpl
+++ b/bootstrap/helm/cluster-api-cluster/values.yaml.tpl
@@ -1,0 +1,61 @@
+{{ $isGcp := or (eq .Provider "google") (eq .Provider "gcp") }}
+enabled: {{ .ClusterAPI }}
+{{- if $isGcp }}
+provider: gcp
+{{- else }}
+provider: {{ .Provider }}
+{{- end }}
+cluster:
+  name: {{ .Cluster }}
+
+  {{- if eq .Provider "aws" }}
+  aws:
+    region: {{ .Region }}
+    iamAuthenticatorConfig:
+      mapRoles:
+      - rolearn: "arn:aws:iam::{{ .Project }}:role/{{ .Cluster }}-capa-controller"
+        username: capa-admin
+        groups:
+        - system:masters
+    {{- if .AvailabilityZones }}
+    network:
+      vpc:
+        availabilityZoneUsageLimit: {{ len .AvailabilityZones }}
+    {{- end }}
+  {{- end }}
+
+  {{- if eq .Provider "azure" }}
+  azure:
+    clusterIdentity:
+      workloadIdentity:
+        clientID: {{ importValue "Terraform" "capz_assigned_identity_client_id" }}
+      tenantID: {{ .Context.TenantId }}
+    subscriptionID: {{ .Context.SubscriptionId }}
+    location: {{ .Region }}
+    resourceGroupName: {{ .Project }}
+    virtualNetwork:
+      name: {{ .Values.network_name | quote }}
+  {{- end }}
+
+  {{- if $isGcp }}
+  gcp:
+    project: {{ .Project }}
+    region: {{ .Region }}
+    network:
+      name: {{ .Values.vpc_name | quote }}
+  {{- end }}
+
+  {{- if eq .Provider "kind" }}
+  serviceCidrBlocks:
+    - 10.128.0.0/12
+  {{- end }}
+
+{{- if eq .Provider "aws" }}
+workers:
+  defaults:
+    aws:
+      spec:
+        {{- if .AvailabilityZones }}
+        availabilityZones: {{ toYaml .AvailabilityZones | nindent 8 }}
+        {{- end }}
+{{- end }}


### PR DESCRIPTION
## Summary
This PR adds the helm chart that deploys clusters using Cluster API to the main branch. It also adds a GitHub action that will run the unit tests for this chart. Many more unit tests should be added for the chart since this will be the code that defines user's infrastructure in the future, with errors or breaking changes in the chart having potential disastrous consequences.