### PR TITLE
fix(gke): bump GKE kubernetes version

### DIFF
--- a/bootstrap/terraform/gcp-bootstrap/deps.yaml
+++ b/bootstrap/terraform/gcp-bootstrap/deps.yaml
@@ -2,7 +2,7 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: Creates a GKE cluster and adds initial configuration
-  version: 0.2.24
+  version: 0.2.25
 spec:
   dependencies: []
   providers:

--- a/bootstrap/terraform/gcp-bootstrap/variables.tf
+++ b/bootstrap/terraform/gcp-bootstrap/variables.tf
@@ -253,7 +253,7 @@ variable "num_static_ips" {
 
 variable "kubernetes_version" {
   type = string
-  default = "1.24.14-gke.1400"
+  default = "1.24.17-gke.200"
 }
 
 variable "vpc_subnetwork_cidr_range" {


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you with us! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
Bumped Kubernetes patch version for GKE installations to the latest patch version. Checked the availability with gcloud CLI on `us-east1` and `europe-centra2l` regions to make sure it is already available.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP