### PR TITLE
fix(bootstrap): allow for disabling azure pod id creation

### DIFF
--- a/bootstrap/helm/bootstrap/Chart.yaml
+++ b/bootstrap/helm/bootstrap/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   email: mguarino46@gmail.com
 - name: David van der Spek
   email: david@plural.sh
-version: 0.8.72
+version: 0.8.73
 dependencies:
 - name: external-dns
   version: 6.14.1

--- a/bootstrap/helm/bootstrap/templates/azure.yaml
+++ b/bootstrap/helm/bootstrap/templates/azure.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.provider "azure" }}
+{{- if and (eq .Values.provider "azure") .Values.azurePodIdentity.enabled }}
 apiVersion: "aadpodidentity.k8s.io/v1"
 kind: AzureIdentity
 metadata:
@@ -17,4 +17,4 @@ metadata:
 spec:
   azureIdentity: externaldns
   selector: externaldns
-{{ end }}
+{{- end }}

--- a/bootstrap/helm/bootstrap/values.yaml
+++ b/bootstrap/helm/bootstrap/values.yaml
@@ -220,3 +220,6 @@ metrics-server:
     tag: 0.6.2
   apiService:
     create: true
+
+azurePodIdentity:
+  enabled: true

--- a/bootstrap/plural/recipes/azure-cluster-api-migrate-test.yaml
+++ b/bootstrap/plural/recipes/azure-cluster-api-migrate-test.yaml
@@ -1,4 +1,4 @@
-name: azure-cluster-api-simple-test
+name: azure-cluster-api-migrate-test
 description: Creates an AKS cluster and installs the bootstrap chart
 provider: AZURE
 primary: false
@@ -19,6 +19,8 @@ sections:
         name: azure-bootstrap
       - type: HELM
         name: bootstrap
+      - type: HELM
+        name: azure-identity
       - type: HELM
         name: plural-certmanager-webhook
       - type: HELM


### PR DESCRIPTION
## Summary
During CAPI bootstrapping there is a conflict with creating the Azure AD Pod Identity resource and the installation of the CRD since that is done by the same chart, causing a classic chicken&egg problem. This PR allows us to disable creation of the resource during cluster bootstrapping where it isn't needed and causes problems. It also creates a second recipe that will allow us to properly test fresh Azure clusters deployed with CAPI.