### PR TITLE
fix: move kubernetes version to template and add gcp unit tests

### DIFF
--- a/bootstrap/helm/cluster-api-cluster/Chart.yaml
+++ b/bootstrap/helm/cluster-api-cluster/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cluster-api-cluster
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.42
+version: 0.1.43
 appVersion: v1.24.16

--- a/bootstrap/helm/cluster-api-cluster/templates/_helpers.tpl
+++ b/bootstrap/helm/cluster-api-cluster/templates/_helpers.tpl
@@ -68,12 +68,6 @@ Creates the Kubernetes version for the cluster
 {{- define "cluster.kubernetesVersion" -}}
 {{- if .Values.cluster.kubernetesVersion -}}
 {{ .Values.cluster.kubernetesVersion }}
-{{- else if eq .Values.provider "aws" -}}
-v1.24
-{{- else if eq .Values.provider "azure" -}}
-v1.25.11
-{{- else if and (eq .Values.provider "gcp") (eq .Values.type "managed") -}}
-1.24.16
 {{- else if eq .Values.provider "kind" -}}
 v1.25.11
 {{- end }}

--- a/bootstrap/helm/cluster-api-cluster/tests/gcp_cluster_test.yaml
+++ b/bootstrap/helm/cluster-api-cluster/tests/gcp_cluster_test.yaml
@@ -1,0 +1,33 @@
+suite: test gcp cluster
+templates:
+  - gcp/cluster.yaml
+tests:
+  - it: should be created with default values when provider is gcp
+    set:
+      provider: gcp
+      type: managed
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: GCPManagedCluster
+      - equal:
+          path: metadata.name
+          value: plural
+      - isNullOrEmpty:
+          path: spec.project
+      - isNullOrEmpty:
+          path: spec.region
+      - lengthEqual:
+          path: spec.network.subnets
+          count: 1
+      - equal:
+          path: spec.network.subnets[0].name
+          value: plural-subnetwork
+  - it: should not be created when provider is not gcp
+    set:
+      type: managed
+    asserts:
+      - hasDocuments:
+          count: 0
+

--- a/bootstrap/helm/cluster-api-cluster/tests/gcp_control_plane_test.yaml
+++ b/bootstrap/helm/cluster-api-cluster/tests/gcp_control_plane_test.yaml
@@ -21,9 +21,6 @@ tests:
           path: spec.project
       - isNullOrEmpty:
           path: spec.location
-      - equal:
-          path: spec.controlPlaneVersion
-          value: "1.24.16"
   - it: should use custom kubernetes version if provided
     set:
       provider: gcp

--- a/bootstrap/helm/cluster-api-cluster/tests/gcp_control_plane_test.yaml
+++ b/bootstrap/helm/cluster-api-cluster/tests/gcp_control_plane_test.yaml
@@ -1,0 +1,71 @@
+suite: test gcp control plane
+templates:
+  - gcp/control-plane.yaml
+tests:
+  - it: should be created with default values when provider is gcp
+    set:
+      provider: gcp
+      type: managed
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: GCPManagedControlPlane
+      - equal:
+          path: metadata.name
+          value: plural
+      - equal:
+          path: spec.clusterName
+          value: plural
+      - isNullOrEmpty:
+          path: spec.project
+      - isNullOrEmpty:
+          path: spec.location
+      - equal:
+          path: spec.controlPlaneVersion
+          value: "1.24.16"
+  - it: should use custom kubernetes version if provided
+    set:
+      provider: gcp
+      type: managed
+      cluster.kubernetesVersion: 1.24
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: GCPManagedControlPlane
+      - equal:
+          path: spec.controlPlaneVersion
+          value: "1.24"
+  - it: should not contain release channel if set to "unspecified"
+    set:
+      provider: gcp
+      type: managed
+      cluster.gcp.releaseChannel: unspecified
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: GCPManagedControlPlane
+      - notExists:
+          path: spec.releaseChannel
+  - it: should contain release channel if set
+    set:
+      provider: gcp
+      type: managed
+      cluster.gcp.releaseChannel: stable
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: GCPManagedControlPlane
+      - equal:
+          path: spec.releaseChannel
+          value: stable
+  - it: should not be created when provider is not gcp
+    set:
+      type: managed
+    asserts:
+      - hasDocuments:
+          count: 0
+

--- a/bootstrap/helm/cluster-api-cluster/tests/gcp_machinepools_test.yaml
+++ b/bootstrap/helm/cluster-api-cluster/tests/gcp_machinepools_test.yaml
@@ -51,15 +51,6 @@ tests:
         equal:
           path: spec.machineType
           value: e2-standard-2
-  - it: should have default kubernetes version set
-    set:
-      provider: gcp
-      type: managed
-    asserts:
-      - documentIndex: 1
-        equal:
-          path: spec.template.spec.version
-          value: "1.24.16"
   - it: should have custom kubernetes version set
     set:
       provider: gcp

--- a/bootstrap/helm/cluster-api-cluster/tests/gcp_machinepools_test.yaml
+++ b/bootstrap/helm/cluster-api-cluster/tests/gcp_machinepools_test.yaml
@@ -1,0 +1,79 @@
+suite: test gcp machine pools
+templates:
+  - gcp/machinepools.yaml
+tests:
+  - it: should be created with default values when provider is gcp
+    set:
+      provider: gcp
+      type: managed
+    asserts:
+      - hasDocuments:
+          count: 6
+      - documentIndex: 0
+        isKind:
+          of: GCPManagedMachinePool
+      - documentIndex: 1
+        isKind:
+          of: MachinePool
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: large-burst-on-demand
+      - documentIndex: 0
+        equal:
+          path: spec.nodePoolName
+          value: large-burst-on-demand
+      - documentIndex: 0
+        equal:
+          path: spec.machineType
+          value: e2-standard-8
+      - documentIndex: 2
+        equal:
+          path: metadata.name
+          value: medium-burst-on-demand
+      - documentIndex: 2
+        equal:
+          path: spec.nodePoolName
+          value: medium-burst-on-demand
+      - documentIndex: 2
+        equal:
+          path: spec.machineType
+          value: e2-standard-4
+      - documentIndex: 4
+        equal:
+          path: metadata.name
+          value: small-burst-on-demand
+      - documentIndex: 4
+        equal:
+          path: spec.nodePoolName
+          value: small-burst-on-demand
+      - documentIndex: 4
+        equal:
+          path: spec.machineType
+          value: e2-standard-2
+  - it: should have default kubernetes version set
+    set:
+      provider: gcp
+      type: managed
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: spec.template.spec.version
+          value: "1.24.16"
+  - it: should have custom kubernetes version set
+    set:
+      provider: gcp
+      type: managed
+      cluster.kubernetesVersion: 1.24
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: spec.template.spec.version
+          value: "1.24"
+  - it: should not be created when provider is not gcp
+    set:
+      type: managed
+    asserts:
+      - hasDocuments:
+          count: 0
+

--- a/bootstrap/helm/cluster-api-cluster/values.yaml
+++ b/bootstrap/helm/cluster-api-cluster/values.yaml
@@ -499,7 +499,6 @@ workers:
   #################################
   azure:
     lsod:
-      kubernetesVersion: v1.25.11
       spec:
         additionalTags: # TODO: allow this to not be set
           ScalingGroup: large-sustained-on-demand
@@ -520,7 +519,6 @@ workers:
     lsspot:
       replicas: 0
       isMultiAZ: true
-      kubernetesVersion: v1.25.11
       spec:
         additionalTags: # TODO: allow this to not be set
           ScalingGroup: large-sustained-spot
@@ -549,7 +547,6 @@ workers:
             key: kubernetes.azure.com/scalesetpriority
             value: spot
     msod:
-      kubernetesVersion: v1.25.11
       spec:
         additionalTags: # TODO: allow this to not be set
           ScalingGroup: medium-sustained-on-demand
@@ -569,7 +566,6 @@ workers:
         sku: Standard_D4as_v5
     msspot:
       isMultiAZ: true
-      kubernetesVersion: v1.25.11
       spec:
         additionalTags: # TODO: allow this to not be set
           ScalingGroup: medium-sustained-spot
@@ -599,7 +595,6 @@ workers:
             value: spot
     ssod:
       replicas: 1
-      kubernetesVersion: v1.25.11
       spec:
         additionalTags: # TODO: allow this to not be set
           ScalingGroup: small-sustained-on-demand
@@ -619,7 +614,6 @@ workers:
         sku: Standard_D2as_v5
     ssspot:
       isMultiAZ: true
-      kubernetesVersion: v1.25.11
       spec:
         additionalTags: # TODO: allow this to not be set
           ScalingGroup: small-sustained-spot

--- a/bootstrap/helm/cluster-api-cluster/values.yaml.tpl
+++ b/bootstrap/helm/cluster-api-cluster/values.yaml.tpl
@@ -9,6 +9,7 @@ cluster:
   name: {{ .Cluster }}
 
   {{- if eq .Provider "aws" }}
+  kubernetesVersion: v1.24
   aws:
     region: {{ .Region }}
     iamAuthenticatorConfig:
@@ -25,6 +26,7 @@ cluster:
   {{- end }}
 
   {{- if eq .Provider "azure" }}
+  kubernetesVersion: v1.25.11
   azure:
     clusterIdentity:
       workloadIdentity:
@@ -38,6 +40,7 @@ cluster:
   {{- end }}
 
   {{- if $isGcp }}
+  kubernetesVersion: 1.24.17
   gcp:
     project: {{ .Project }}
     region: {{ .Region }}


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you with us! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
- add helm units tests for GCP provider
- move default kubernetes version from helper file to values template

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Locally with link

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP