### PR TITLE
fix(bootstrap): use vendored kubectl image for CAPI

### DIFF
--- a/.github/workflows/matrix-vendor-and-publish.yml
+++ b/.github/workflows/matrix-vendor-and-publish.yml
@@ -235,10 +235,10 @@ jobs:
     - name: Install @semantic-release/commit-analyzer
       run: npm install -g @semantic-release/commit-analyzer
     - name: installing plural
-      uses: pluralsh/setup-plural@v0.1.5
+      uses: pluralsh/setup-plural@v0.1.9
       with:
         config: ${{ secrets.PLURAL_CONF }}
-        vsn: 0.7.6
+        vsn: 0.7.8
     - run: plural apply -f ${{ matrix.pluralfile }}
     - name: 'Run Semantic Release'
       run: APP_NAME=${{ matrix.repository }} semantic-release

--- a/bootstrap/helm/cluster-api-bootstrap/Chart.yaml
+++ b/bootstrap/helm/cluster-api-bootstrap/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-api-bootstrap
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "v1.5.1"
 dependencies:
 - name: cluster-api-bootstrap

--- a/bootstrap/helm/cluster-api-bootstrap/values.yaml
+++ b/bootstrap/helm/cluster-api-bootstrap/values.yaml
@@ -10,6 +10,6 @@ job:
     helm.sh/hook-weight: "-5"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   image:
-    repository: bitnami/kubectl
+    repository: gcr.io/pluralsh/bitnami/kubectl
     tag: 1.25.8
     pullPolicy: IfNotPresent

--- a/bootstrap/helm/cluster-api-control-plane/Chart.yaml
+++ b/bootstrap/helm/cluster-api-control-plane/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-api-control-plane
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "v1.5.1"
 dependencies:
 - name: cluster-api-control-plane

--- a/bootstrap/helm/cluster-api-control-plane/values.yaml
+++ b/bootstrap/helm/cluster-api-control-plane/values.yaml
@@ -9,6 +9,6 @@ job:
     helm.sh/hook-weight: "-5"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   image:
-    repository: bitnami/kubectl
+    repository: gcr.io/pluralsh/bitnami/kubectl
     tag: 1.25.8
     pullPolicy: IfNotPresent

--- a/bootstrap/helm/cluster-api-core/Chart.yaml
+++ b/bootstrap/helm/cluster-api-core/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-api-core
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "v1.5.1"
 dependencies:
 - name: cluster-api-core

--- a/bootstrap/helm/cluster-api-core/values.yaml
+++ b/bootstrap/helm/cluster-api-core/values.yaml
@@ -12,6 +12,6 @@ job:
     helm.sh/hook-weight: "-5"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   image:
-    repository: bitnami/kubectl
+    repository: gcr.io/pluralsh/bitnami/kubectl
     tag: 1.25.8
     pullPolicy: IfNotPresent

--- a/bootstrap/helm/cluster-api-provider-aws/Chart.yaml
+++ b/bootstrap/helm/cluster-api-provider-aws/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-api-provider-aws
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: "v2.2.1"
 dependencies:
 - name: cluster-api-provider-aws

--- a/bootstrap/helm/cluster-api-provider-aws/values.yaml
+++ b/bootstrap/helm/cluster-api-provider-aws/values.yaml
@@ -25,6 +25,6 @@ job:
     helm.sh/hook-weight: "-5"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   image:
-    repository: bitnami/kubectl
+    repository: gcr.io/pluralsh/bitnami/kubectl
     tag: 1.25.8
     pullPolicy: IfNotPresent

--- a/bootstrap/helm/cluster-api-provider-azure/Chart.yaml
+++ b/bootstrap/helm/cluster-api-provider-azure/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-api-provider-azure
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.11
+version: 0.1.12
 appVersion: v1.10.2
 dependencies:
 - name: cluster-api-provider-azure

--- a/bootstrap/helm/cluster-api-provider-azure/values.yaml
+++ b/bootstrap/helm/cluster-api-provider-azure/values.yaml
@@ -21,6 +21,6 @@ job:
     helm.sh/hook-weight: "-5"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   image:
-    repository: bitnami/kubectl
+    repository: gcr.io/pluralsh/bitnami/kubectl
     tag: 1.25.8
     pullPolicy: IfNotPresent

--- a/bootstrap/helm/cluster-api-provider-docker/Chart.yaml
+++ b/bootstrap/helm/cluster-api-provider-docker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-api-provider-docker
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "v1.5.1"
 dependencies:
 - name: cluster-api-provider-docker

--- a/bootstrap/helm/cluster-api-provider-docker/values.yaml
+++ b/bootstrap/helm/cluster-api-provider-docker/values.yaml
@@ -10,6 +10,6 @@ job:
     helm.sh/hook-weight: "-5"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   image:
-    repository: bitnami/kubectl
+    repository: gcr.io/pluralsh/bitnami/kubectl
     tag: 1.25.8
     pullPolicy: IfNotPresent

--- a/bootstrap/helm/cluster-api-provider-gcp/Chart.yaml
+++ b/bootstrap/helm/cluster-api-provider-gcp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-api-provider-gcp
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.12
+version: 0.1.13
 appVersion: v1.4.5
 dependencies:
 - name: cluster-api-provider-gcp

--- a/bootstrap/helm/cluster-api-provider-gcp/values.yaml
+++ b/bootstrap/helm/cluster-api-provider-gcp/values.yaml
@@ -21,6 +21,6 @@ job:
     helm.sh/hook-weight: "-5"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   image:
-    repository: bitnami/kubectl
+    repository: gcr.io/pluralsh/bitnami/kubectl
     tag: 1.25.8
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary
This PR ensures we use vendored images for `kubectl` in the CAPI charts so we avoid docker rate limits. It also updates the `setup-plural` action since the current version seems to be broken with newer versions of the CLI.