### PR TITLE
fix(bootstrap): allow for disabling external dns

### DIFF
--- a/bootstrap/helm/bootstrap/Chart.yaml
+++ b/bootstrap/helm/bootstrap/Chart.yaml
@@ -10,11 +10,12 @@ maintainers:
   email: mguarino46@gmail.com
 - name: David van der Spek
   email: david@plural.sh
-version: 0.8.74
+version: 0.8.75
 dependencies:
 - name: external-dns
   version: 6.14.1
   repository: https://charts.bitnami.com/bitnami
+  condition: external-dns.enabled
 - name: metrics-server
   version: 6.2.12
   condition: metrics-server.enabled

--- a/bootstrap/helm/bootstrap/values.yaml
+++ b/bootstrap/helm/bootstrap/values.yaml
@@ -4,6 +4,7 @@ acme:
   # secret: ""
 
 external-dns:
+  enabled: true
   serviceAccount:
     name: external-dns
     create: true


### PR DESCRIPTION
## Summary
This PR allows us and users to disable the external-dns subchart.