### PR TITLE
fix(capi-cluster): add labels and annotations to machinepool

### DIFF
--- a/bootstrap/helm/cluster-api-cluster/Chart.yaml
+++ b/bootstrap/helm/cluster-api-cluster/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cluster-api-cluster
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.43
+version: 0.1.44
 appVersion: v1.24.16

--- a/bootstrap/helm/cluster-api-cluster/templates/_helpers.tpl
+++ b/bootstrap/helm/cluster-api-cluster/templates/_helpers.tpl
@@ -208,6 +208,17 @@ metadata:
   name: {{ .name }}
   annotations:
     helm.sh/resource-policy: keep
+    {{- if (hasKey .values "annotations") -}}
+    {{- toYaml (merge .values.annotations .defaultVals.annotations)| nindent 4 }}
+    {{- else -}}
+    {{- toYaml .defaultVals.annotations | nindent 4 }}
+    {{- end }}
+  labels:
+    {{- if (hasKey .values "labels") -}}
+    {{- toYaml (merge .values.labels .defaultVals.labels)| nindent 4 }}
+    {{- else -}}
+    {{- toYaml .defaultVals.labels | nindent 4 }}
+    {{- end }}
 spec:
   clusterName: {{ .ctx.Values.cluster.name }}
   replicas: {{ $replicas }}

--- a/bootstrap/helm/cluster-api-cluster/tests/aws_machinepools_test.yaml
+++ b/bootstrap/helm/cluster-api-cluster/tests/aws_machinepools_test.yaml
@@ -30,6 +30,8 @@ tests:
       type: managed
       cluster.aws.region: abc
       cluster.kubernetesVersion: v1.2.3
+      workers.defaults.aws.labels:
+        test: test
       workers.defaults.aws.spec.availabilityZones:
       - us-east-1a
       - us-east-1b
@@ -39,10 +41,77 @@ tests:
           path: spec.amiType
           value: AL2_x86_64
         documentIndex: 0
+      - isSubset:
+          path: metadata.labels
+          content:
+            test: test
+      - isSubset:
+          path: metadata.annotations
+          content:
+            cluster.x-k8s.io/replicas-managed-by: external-autoscaler
       - equal:
           path: spec.diskSize
           value: 50
         documentIndex: 2
+    template: aws/machinepools.yaml
+  - it: test override
+    set:
+      cluster.name: test
+      provider: aws
+      type: managed
+      cluster.aws.region: abc
+      cluster.kubernetesVersion: v1.2.3
+      workers.defaults.aws.spec.availabilityZones:
+      - us-east-1a
+      - us-east-1b
+      - us-east-1c
+      workers.aws.small-burst-spot:
+        labels:
+          test: test
+        annotations:
+          test: test
+        spec:
+          amiType: AL2_x86_64_GPU
+          diskSize: 100
+    asserts:
+      - equal:
+          path: spec.eksNodegroupName
+          value: small-burst-spot
+        documentIndex: 22
+      - equal:
+          path: metadata.name
+          value: small-burst-spot
+        documentIndex: 23
+      - isSubset:
+          path: metadata.labels
+          content:
+            test: test
+        documentIndex: 22
+      - isSubset:
+          path: metadata.annotations
+          content:
+            cluster.x-k8s.io/replicas-managed-by: external-autoscaler
+            test: test
+        documentIndex: 22
+      - isSubset:
+          path: metadata.labels
+          content:
+            test: test
+        documentIndex: 23
+      - isSubset:
+          path: metadata.annotations
+          content:
+            cluster.x-k8s.io/replicas-managed-by: external-autoscaler
+            test: test
+        documentIndex: 23
+      - equal:
+          path: spec.diskSize
+          value: 100
+        documentIndex: 22
+      - equal:
+          path: spec.amiType
+          value: AL2_x86_64_GPU
+        documentIndex: 22
     template: aws/machinepools.yaml
   - it: test large-burst-spot
     set:

--- a/bootstrap/helm/cluster-api-cluster/tests/gcp_machinepools_test.yaml
+++ b/bootstrap/helm/cluster-api-cluster/tests/gcp_machinepools_test.yaml
@@ -6,6 +6,8 @@ tests:
     set:
       provider: gcp
       type: managed
+      workers.defaults.gcp.labels:
+        test: test
     asserts:
       - hasDocuments:
           count: 6
@@ -51,6 +53,14 @@ tests:
         equal:
           path: spec.machineType
           value: e2-standard-2
+      - isSubset:
+          path: metadata.labels
+          content:
+            test: test
+      - isSubset:
+          path: metadata.annotations
+          content:
+            cluster.x-k8s.io/replicas-managed-by: external-autoscaler
   - it: should have custom kubernetes version set
     set:
       provider: gcp
@@ -67,4 +77,3 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
-


### PR DESCRIPTION
## Summary
This PR fixes that the labels and annotations weren't being set on the `MachinePool` object. This meant that autoscaling wasn't working, since the annotation to specify an external autoscaler is being used needs to be on the `MachinePool` resource.

## Test Plan
Add new unit tests that ensures the labels and annotations from the AWS and GCP node pool defaults and node pool overrides are propagated onto the GCP and AWS managed machine pool and `MachinePool` resources.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP