### PR TITLE
fix(chatwoot): set correct app version

### DIFF
--- a/chatwoot/helm/chatwoot/Chart.yaml
+++ b/chatwoot/helm/chatwoot/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: chatwoot
 description: Open-source customer engagement suite, an alternative to Intercom, Zendesk, Salesforce Service Cloud etc.
 type: application
-version: 0.1.9
-appVersion: v2.15.0
+version: 0.1.10
+appVersion: v3.1.0
 dependencies:
 - name: chatwoot
   version: 1.1.2


### PR DESCRIPTION
## Summary
The app version wasn't updated in the last update. This PR updates it so it doesn't confuse users.