### PR TITLE
Make kubernetes executor default for airflow

### DIFF
--- a/airflow/helm/airflow/Chart.yaml
+++ b/airflow/helm/airflow/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: airflow
 description: A Helm chart for airflow deployable on plural
 type: application
-version: 0.3.39
+version: 0.3.40
 appVersion: "2.6.3"
 sources:
   - https://github.com/pluralsh/plural-artifacts/airflow/helm/airflow

--- a/airflow/helm/airflow/values.yaml
+++ b/airflow/helm/airflow/values.yaml
@@ -12,7 +12,7 @@ httpConfig:
   password: dummy
 
 secrets:
-  createPluralRedisSecret: false
+  createPluralRedisSecret: true
   redis_password: example
 
 test-base:
@@ -257,7 +257,7 @@ airflow:
   
   flower:
     enabled: false
-  
+
   rbac:
     create: true
   
@@ -268,7 +268,7 @@ airflow:
     image:
       registry: gcr.io/pluralsh
       tag: 6.0.9-debian-10-r0
-    enabled: true
+    enabled: false
     existingSecret: airflow-redis-password
     existingSecretPasswordKey: redis-password
 
@@ -310,11 +310,20 @@ airflow:
     passwordSecretKey: redis-password
 
   airflow:
-    executor: CeleryExecutor
+    executor: KubernetesExecutor
     image:
       repository: ghcr.io/pluralsh/containers/apache/airflow
       tag: 2.6.3-python3.10-plural1.4.4
 
+    kubernetesPodTemplate:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 500Mi
+        limits:
+          cpu: 500m
+          memory: 1.5Gi
+  
     config:
       ## security
       AIRFLOW__WEBSERVER__EXPOSE_CONFIG: "False"
@@ -383,7 +392,7 @@ airflow:
   workers:
     ## if the airflow workers StatefulSet should be deployed
     ##
-    enabled: true
+    enabled: false
 
     replicas: 2
 


### PR DESCRIPTION
## Summary

This is just an overall simpler architecture (but more resource intensive), so probably the saner default.  Also removes complexity of an internal redis.

## Test Plan
link


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP