### PR TITLE
docs: Add a guide for running airbyte workloads on custom nodes

### DIFF
--- a/airbyte/plural/docs/running-on-custom-nodes.md
+++ b/airbyte/plural/docs/running-on-custom-nodes.md
@@ -1,0 +1,61 @@
+## Running Airbyte Workloads on Custom Node Group
+
+There may be a desire to run your Airbyte workloads on a specific node size for large workloads, or maybe even 
+[spot instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-spot-instances.html) to achieve higher cost 
+savings.
+
+### create custom node group
+
+In order to run your Airbyte Workloads on custom configured nodes, you will need to first follow [these docs](https://docs.plural.sh/operations/cluster-configuration#modifying-node-types)
+to create your desired nodes. For example, if you were on AWS and wanted to use spot instances you would add something 
+like this to your `bootstrap/terraform/main.tf` file:
+
+```yaml
+multi_az_node_groups = {
+  medium_burst_spot = {
+      name = "medium-burst-spot"
+      min_capacity = 3
+      desired_capacity = 3
+      instance_types = ["t3.xlarge", "t3a.xlarge"]
+      capacity_type = "SPOT"
+      k8s_labels = {
+        "plural.sh/capacityType" = "SPOT"
+        "plural.sh/performanceType" = "BURST"
+        "plural.sh/scalingGroup" = "medium-burst-spot"
+      }
+      k8s_taints = [{
+        key = "plural.sh/capacityType"
+        value = "SPOT"
+        effect = "NO_SCHEDULE"
+      }]
+    }
+}
+```
+
+Then run `plural deploy --commit "add more spot nodes"` to update your cluster.
+
+> ! If you get an error like `InvalidParameterException: Minimum capacity 3 can't be greater than desired size 0` you 
+> may have to use your cloud CLI or console to enact the change manually and then try running again.
+
+### update airbyte to use node group
+
+After creating your custom node group, you can point configure Airbyte to use it by adding the following to your 
+`./airbyte/helm/values.yaml` (this can also be done in the plural application console)
+
+```yaml
+global:
+  jobs:
+    kube:
+      nodeSelector:
+        plural.sh/capacityType: SPOT
+      tolerations:
+      - effect: NoSchedule
+        key: plural.sh/capacityType
+        operator: Equal
+        value: SPOT
+```
+
+### redeploy
+
+From there, you should be able to run `plural build --only airbyte && plural deploy --commit "run on spot instances"` to 
+use the custom node group to execute your workloads.


### PR DESCRIPTION
## Summary

If your customers want to run Airbyte workloads on a specific node type, this should get them started.


## Test Plan

I'm using the documented configuration on my plural.sh hosted Airbyte and it's working great.


## Checklist

- [x]  No images hosted from dockerhub
- [x]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [x]  all databases should have dashboards
    - [x]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [x]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [x]  Are scaling runbooks present
    - [x]  all databases **must** have scaling runbooks
    - [x]  you can use the charts in `pluralsh/module-library` to accelerate this
- [x]  do you need to add config overlays?
    - [x]  inputing secrets
    - [x]  configuring autoscaling
- [x]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [x]  All major clouds must be supported
    - [x]  Azure
    - [x]  AWS
    - [x]  GCP

___

Checklist isn't very applicable because it's a simple doc add. Let me know if I missed anything 🍻