### PR TITLE
feat(gcp): let helm manage certmanager SA instead of terraform

### DIFF
--- a/bootstrap/helm/bootstrap/Chart.yaml
+++ b/bootstrap/helm/bootstrap/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   email: mguarino46@gmail.com
 - name: David van der Spek
   email: david@plural.sh
-version: 0.8.77
+version: 0.8.78
 dependencies:
 - name: external-dns
   version: 6.14.1

--- a/bootstrap/helm/bootstrap/values.yaml.tpl
+++ b/bootstrap/helm/bootstrap/values.yaml.tpl
@@ -183,9 +183,13 @@ dnsSolver:
 
 {{ if $isGcp }}
 cert-manager:
+  podAnnotations:
+    checksum/sa: {{ importValue "Terraform" "certmanager_sa_workload_identity_email" | sha256sum }}
   serviceAccount:
-    create: false
+    create: true
     name: certmanager
+    annotations:
+      iam.gke.io/gcp-service-account: {{ importValue "Terraform" "certmanager_sa_workload_identity_email" }}
 
 {{ if not $pluraldns }}
 dnsSolver:

--- a/bootstrap/terraform/gcp-bootstrap/deps.yaml
+++ b/bootstrap/terraform/gcp-bootstrap/deps.yaml
@@ -11,5 +11,6 @@ spec:
     cluster: cluster
     vpc_network: vpc_network
     capi_sa_workload_identity_email: capi_sa_workload_identity_email
+    certmanager_sa_workload_identity_email: certmanager_sa_workload_identity_email
   provider_wirings:
     cluster: module.gcp-bootstrap.cluster

--- a/bootstrap/terraform/gcp-bootstrap/main.tf
+++ b/bootstrap/terraform/gcp-bootstrap/main.tf
@@ -104,7 +104,7 @@ resource "kubernetes_namespace" "bootstrap" {
 }
 
 resource "kubernetes_service_account" "certmanager" {
-  count = var.cluster_api ? 0 : 1
+  count = var.cluster_api ? 0 : 0
   metadata {
     name      = "certmanager"
     namespace = var.namespace

--- a/bootstrap/terraform/gcp-bootstrap/outputs.tf
+++ b/bootstrap/terraform/gcp-bootstrap/outputs.tf
@@ -10,3 +10,7 @@ output "vpc_network" {
 output "capi_sa_workload_identity_email" {
   value = module.capi-workload-identity.gcp_service_account_email
 }
+
+output "certmanager_sa_workload_identity_email" {
+  value = module.certmanager-workload-identity.gcp_service_account_email
+}

--- a/bootstrap/terraform/gcp-bootstrap/variables.tf
+++ b/bootstrap/terraform/gcp-bootstrap/variables.tf
@@ -253,7 +253,7 @@ variable "num_static_ips" {
 
 variable "kubernetes_version" {
   type = string
-  default = "1.24.17-gke.200"
+  default = "1.24.17-gke.2211000"
 }
 
 variable "vpc_subnetwork_cidr_range" {


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you with us! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
It relies on terraform being executed first and removing `certmanager` SA. Then helm will recreate it with proper annotation and cert-manager deployment should get restarted thanks to new `checksum/sa` annotation.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Locally with link

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP