### PR TITLE
feat: Add support for mimir on gcp

### DIFF
--- a/mimir/helm/mimir/Chart.yaml
+++ b/mimir/helm/mimir/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mimir
 description: helm chart for mimir
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: 2.7.1
 dependencies:
 - name: mimir-distributed

--- a/mimir/helm/mimir/values.yaml.tpl
+++ b/mimir/helm/mimir/values.yaml.tpl
@@ -52,6 +52,11 @@ mimir-distributed:
     annotations:
       eks.amazonaws.com/role-arn: {{ importValue "Terraform" "iam_role_arn" }}
   {{- end }}
+  {{- if $isGcp }}
+  serviceAccount:
+    annotations:
+      iam.gke.io/gcp-service-account: {{ importValue "Terraform" "service_account_email" }}
+  {{ end }}
   {{- if and .Values.basicAuth .Values.hostname (not $traceShield) }}
   gateway:
     enabledNonEnterprise: true

--- a/mimir/plural/recipes/mimir-gcp.yaml
+++ b/mimir/plural/recipes/mimir-gcp.yaml
@@ -2,7 +2,6 @@ name: mimir-gcp
 description: Installs mimir on an aws eks cluster
 provider: GCP
 primary: true
-private: true
 dependencies:
 - repo: bootstrap
   name: gcp-k8s

--- a/mimir/terraform/gcp/deps.yaml
+++ b/mimir/terraform/gcp/deps.yaml
@@ -2,7 +2,7 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: mimir gcp setup
-  version: 0.1.0
+  version: 0.1.1
 spec:
   dependencies:
   - name: gcp-bootstrap
@@ -11,3 +11,5 @@ spec:
     version: '>= 0.1.1'
   providers:
   - gcp
+  outputs:
+    service_account_email: service_account_email

--- a/mimir/terraform/gcp/main.tf
+++ b/mimir/terraform/gcp/main.tf
@@ -25,7 +25,7 @@ module "gcs_buckets" {
   source = "github.com/pluralsh/module-library//terraform/gcs-buckets"
 
   project_id            = var.project_id
-  bucket_names          = [var.dagster_bucket]
-  service_account_email = module.dagster-workload-identity.gcp_service_account_email
+  bucket_names          = [var.mimir_blocks_bucket, var.mimir_alert_bucket, var.mimir_ruler_bucket]
+  service_account_email = module.mimir-workload-identity.gcp_service_account_email
   location              = var.bucket_location
 }

--- a/mimir/terraform/gcp/main.tf
+++ b/mimir/terraform/gcp/main.tf
@@ -9,3 +9,23 @@ resource "kubernetes_namespace" "mimir" {
   }
 }
 
+
+module "mimir-workload-identity" {
+  source              = "terraform-google-modules/kubernetes-engine/google//modules/workload-identity"
+  name                = "${var.cluster_name}-mimir-sa"
+  namespace           = var.namespace
+  project_id          = var.project_id
+  use_existing_k8s_sa = true
+  annotate_k8s_sa     = false
+  k8s_sa_name         = var.mimir_serviceaccount
+  roles               = ["roles/storage.admin"]
+}
+
+module "gcs_buckets" {
+  source = "github.com/pluralsh/module-library//terraform/gcs-buckets"
+
+  project_id            = var.project_id
+  bucket_names          = [var.dagster_bucket]
+  service_account_email = module.dagster-workload-identity.gcp_service_account_email
+  location              = var.bucket_location
+}

--- a/mimir/terraform/gcp/outputs.tf
+++ b/mimir/terraform/gcp/outputs.tf
@@ -1,0 +1,3 @@
+output "service_account_email" {
+    value = module.mimir-workload-identity.gcp_service_account_email
+}

--- a/mimir/terraform/gcp/terraform.tfvars
+++ b/mimir/terraform/gcp/terraform.tfvars
@@ -1,2 +1,6 @@
 namespace = {{ .Namespace | quote }}
 cluster_name = {{ .Cluster | quote }}
+mimir_blocks_bucket = {{ .Values.mimirBlocksBucket | quote }}
+mimir_alert_bucket = {{ .Values.mimirAlertBucket | quote }}
+mimir_ruler_bucket = {{ .Values.mimirRulerBucket | quote }}
+bucket_location = {{ .Context.BucketLocation | quote }}

--- a/mimir/terraform/gcp/variables.tf
+++ b/mimir/terraform/gcp/variables.tf
@@ -6,3 +6,8 @@ variable "namespace" {
 variable "cluster_name" {
   type = string
 }
+
+variable "mimir_serviceaccount" {
+  type = string
+  default = "mimir"
+}

--- a/mimir/terraform/gcp/variables.tf
+++ b/mimir/terraform/gcp/variables.tf
@@ -11,3 +11,19 @@ variable "mimir_serviceaccount" {
   type = string
   default = "mimir"
 }
+
+variable "mimir_blocks_bucket" {
+  type = string
+}
+
+variable "mimir_alert_bucket" {
+  type = string
+}
+
+variable "mimir_ruler_bucket" {
+  type = string
+}
+
+variable "bucket_location" {
+  type = string
+}


### PR DESCRIPTION
## Summary
Will use this to test grafana agent on our cd-demo cluster


## Test Plan
local


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP