### PR TITLE
feat: Override superset secret key

### DIFF
--- a/superset/helm/superset/Chart.yaml
+++ b/superset/helm/superset/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: superset
 description: A Helm chart for superset on plural
 type: application
-version: 0.2.10
+version: 0.2.11
 appVersion: "2.1.0"
 dependencies:
 - name: superset

--- a/superset/helm/superset/templates/reencrypt-secrets.yaml
+++ b/superset/helm/superset/templates/reencrypt-secrets.yaml
@@ -1,0 +1,64 @@
+{{ if .Values.reencrypt }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    job-name: superset-reencrypt-secrets
+  name: superset-reencrypt-secrets
+spec:
+  backoffLimit: 6
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        job-name: superset-reencrypt-secrets
+      name: superset-reencrypt-secrets
+    spec:
+      containers:
+      - command:
+        -  /bin/sh
+        - -c
+        - "superset re-encrypt-secrets"
+        env:
+        - name: DB_PASS
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: superset.plural-superset.credentials.postgresql.acid.zalan.do
+        envFrom:
+        - secretRef:
+            name: superset-env
+        image: dkr.plural.sh/superset/apache/superset:2.1.0-plural1.1.1
+        imagePullPolicy: Always
+        name: superset-init-db
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /app/pythonpath
+          name: superset-config
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      initContainers:
+      - command:
+        - /bin/sh
+        - -c
+        - dockerize -wait "tcp://$DB_HOST:$DB_PORT" -timeout 120s
+        envFrom:
+        - secretRef:
+            name: superset-env
+        image: jwilder/dockerize:latest
+        imagePullPolicy: IfNotPresent
+        name: wait-for-postgres
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      restartPolicy: Never
+      securityContext:
+        runAsUser: 0
+      volumes:
+      - name: superset-config
+        secret:
+          defaultMode: 420
+          secretName: superset-config
+{{ end }}

--- a/superset/helm/superset/values.yaml
+++ b/superset/helm/superset/values.yaml
@@ -109,6 +109,7 @@ configOverlays:
     - path: ['superset', 'superset', 'redis', 'master', 'resources', 'requests', 'memory']
 
 superset:
+  reencrypt: true
   image:
     repository: dkr.plural.sh/superset/apache/superset
     tag: 2.1.0-plural1.1.1

--- a/superset/helm/superset/values.yaml.tpl
+++ b/superset/helm/superset/values.yaml.tpl
@@ -9,7 +9,12 @@ global:
     - description: superset web ui
       url: {{ .Values.hostname }}
 
+{{ $secretKey := dedupe . "superset.secretKey" (randAlphaNum 26) }}
+secretKey: {{ $secretKey }}
+
 superset:
+  extraSecretEnv:
+    SUPERSET_SECRET_KEY: {{ $secretKey }}
   init:
     adminUser:
       username: {{ .Values.username }}
@@ -82,6 +87,9 @@ superset:
 
       # force users to re-auth after 1d
       PERMANENT_SESSION_LIFETIME = 60 * 60 * 24
+
+      PREVIOUS_SECRET_KEY = "thisISaSECRET_1234"
+      SECRET_KEY = "{{ $secretKey }}"
 
       ENABLE_PROXY_FIX = True
   {{ end }}


### PR DESCRIPTION
## Summary

Looks like this isn't set properly via the chart, setting ourselves manually here.


## Test Plan
local link


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP