### PR TITLE
feat: Fix eks addon version

### DIFF
--- a/bootstrap/terraform/aws-bootstrap/deps.yaml
+++ b/bootstrap/terraform/aws-bootstrap/deps.yaml
@@ -2,9 +2,9 @@ apiVersion: plural.sh/v1alpha1
 kind: Dependencies
 metadata:
   description: Creates an EKS cluster and prepares it for bootstrapping
-  version: 0.1.55
+  version: 0.1.56
 spec:
-  breaking: true
+  breaking: false
   dependencies: []
   providers:
   - aws

--- a/bootstrap/terraform/aws-bootstrap/variables.tf
+++ b/bootstrap/terraform/aws-bootstrap/variables.tf
@@ -73,7 +73,7 @@ variable "core_dns_addon_version" {
 
 variable "kube_proxy_addon_version" {
   type = string
-  default = "v1.25.16-minimal-eksbuild.1"
+  default = "v1.25.16-eksbuild.1"
   description = "The version of the kube-proxy addon to use"
 }
 


### PR DESCRIPTION
## Summary
Apparently the minimal build isn't actually generally present despite docs


## Test Plan
n/a


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP