### PR TITLE
feat: Fix airflow double-labelling

### DIFF
--- a/airflow/helm/airflow/Chart.yaml
+++ b/airflow/helm/airflow/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: airflow
 description: A Helm chart for airflow deployable on plural
 type: application
-version: 0.3.40
+version: 0.3.41
 appVersion: "2.6.3"
 sources:
   - https://github.com/pluralsh/plural-artifacts/airflow/helm/airflow

--- a/airflow/helm/airflow/templates/statsd-exporter.yaml
+++ b/airflow/helm/airflow/templates/statsd-exporter.yaml
@@ -103,7 +103,6 @@ metadata:
   name: statsd-exporter
   labels:
   {{- include "airflow.labels" . | nindent 4 }}
-  {{- include "statsd-exporter.selectorLabels" . | nindent 4 }}
   {{- with .Values.exporter.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
## Summary
The statsd exporter service used app.kubernetes.io/name twice

## Test Plan
n/a


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP