### PR TITLE
chore: Add missing posthog-azure.yaml to add azure provider for Posthog

### DIFF
--- a/posthog/plural/recipes/posthog-azure.yaml
+++ b/posthog/plural/recipes/posthog-azure.yaml
@@ -1,0 +1,36 @@
+name: posthog-azure
+description: Installs posthog on an Azure AKS cluster
+provider: AZURE
+primary: true
+dependencies:
+- repo: bootstrap
+  name: azure-k8s
+- repo: ingress-nginx
+  name: ingress-nginx-azure
+- repo: postgres
+  name: azure-postgres
+- repo: clickhouse
+  name: clickhouse-azure
+- repo: redis
+  name: azure-redis
+- repo: kafka
+  name: azure-kafka
+sections:
+- name: posthog
+  configuration:
+  - name: hostname
+    documentation: FQDN to use for your posthog installation
+    type: DOMAIN
+  - name: posthogBucket
+    documentation: Azure Blob Storage container to use for PostHog
+    type: BUCKET
+    default: posthog
+  - name: notificationEmail
+    documentation: Email for notifications to be sent to from the PostHog stack
+    type: STRING
+    optional: true
+  items:
+  - type: TERRAFORM
+    name: azure
+  - type: HELM
+    name: posthog


### PR DESCRIPTION


## Summary
Create a recipe named posthog-azure.yaml in posthog/plural/recipes to add Azure provider for Posthog in the Plural marketplace.

