### PR TITLE
feat(kafka): allow pod template customizations

### DIFF
--- a/kafka/helm/kafka/Chart.yaml
+++ b/kafka/helm/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kafka
 description: A Helm chart for Kubernetes
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: "3.4.0"
 dependencies:
 - name: strimzi-kafka-operator

--- a/kafka/helm/kafka/templates/kafka.yaml
+++ b/kafka/helm/kafka/templates/kafka.yaml
@@ -10,9 +10,7 @@ spec:
     template:
       {{- if .Values.kafka.podTemplate }}
       pod:
-        {{- with .Values.kafka.podTemplate }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- toYaml .Values.kafka.podTemplate | nindent 8 }}
       {{- end }}
       bootstrapService:
         metadata:
@@ -84,9 +82,7 @@ spec:
     template:
       {{- if .Values.zookeeperPodTemplate }}
       pod:
-        {{- with .Values.zookeeperPodTemplate }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- toYaml .Values.zookeeperPodTemplate | nindent 8 }}
       {{- end }}
       clientService:
         metadata:

--- a/kafka/helm/kafka/templates/kafka.yaml
+++ b/kafka/helm/kafka/templates/kafka.yaml
@@ -8,6 +8,12 @@ spec:
     replicas: {{ .Values.kafka.replicas }}
     version: {{ .Values.kafka.version }}
     template:
+      {{- if .Values.kafka.podTemplate }}
+      pod:
+        {{- with .Values.kafka.podTemplate }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
       bootstrapService:
         metadata:
           labels:
@@ -76,6 +82,12 @@ spec:
   zookeeper:
   {{ toYaml .Values.zookeeper | nindent 4 }}
     template:
+      {{- if .Values.zookeeperPodTemplate }}
+      pod:
+        {{- with .Values.zookeeperPodTemplate }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
       clientService:
         metadata:
           labels:

--- a/kafka/helm/kafka/templates/kafka.yaml
+++ b/kafka/helm/kafka/templates/kafka.yaml
@@ -8,9 +8,9 @@ spec:
     replicas: {{ .Values.kafka.replicas }}
     version: {{ .Values.kafka.version }}
     template:
-      {{- if .Values.kafka.podTemplate }}
+      {{- if .Values.kafkaPodTemplate }}
       pod:
-        {{- toYaml .Values.kafka.podTemplate | nindent 8 }}
+        {{- toYaml .Values.kafkaPodTemplate | nindent 8 }}
       {{- end }}
       bootstrapService:
         metadata:


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you with us! -->

## Summary
Allow pod template customizations on the strimzi kafka CRD. This will allow operators to set up `podAffinity` blocks and more.

A good use case for this feature is configuring all kafka/zookeper pods to run on different nodes: [strimzi docs](https://strimzi.io/docs/operators/0.35.1/full/configuring#configuring-pod-anti-affinity-to-schedule-each-kafka-broker-on-a-different-worker-node-str)