### PR TITLE
feat(datadog): update datadog chart version

### DIFF
--- a/datadog/helm/datadog/Chart.yaml
+++ b/datadog/helm/datadog/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: datadog
 description: helm chart for datadog
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "v1.0.0"
 dependencies:
 - name: config-overlays
   version: 0.1.1
   repository: https://pluralsh.github.io/module-library
 - name: datadog
-  version: 2.36.1
+  version: 3.59.4
   repository: https://helm.datadoghq.com


### PR DESCRIPTION
Bump official DataDog chart version

2.36.1 → 3.59.4