### PR TITLE
fix: deprecated jwt decode method

### DIFF
--- a/airflow/helm/airflow/Chart.yaml
+++ b/airflow/helm/airflow/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: airflow
 description: A Helm chart for airflow deployable on plural
 type: application
-version: 0.3.42
+version: 0.3.43
 appVersion: "2.6.3"
 sources:
   - https://github.com/pluralsh/plural-artifacts/airflow/helm/airflow

--- a/airflow/helm/airflow/values.yaml.tpl
+++ b/airflow/helm/airflow/values.yaml.tpl
@@ -68,7 +68,7 @@ airflow:
         class PluralSecurityManager(AirflowSecurityManager):
           def _get_oauth_user_info(self, provider, response):
               if provider == "plural":
-                  me = self._azure_jwt_token_parse(response["id_token"])
+                  me = jwt.decode(response["id_token"], options={"verify_signature": False})
                   split_name = me["name"].split()
                   return {
                       "username": me["name"],


### PR DESCRIPTION
## Summary
Later versions of airflow removed this function on us, but looks like we can just use a function bound to the jwt library itself directly.


## Test Plan
n/a

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP