### PR TITLE
feat: Allow mysql to be disabled in ghost chart

### DIFF
--- a/ghost/helm/ghost/Chart.yaml
+++ b/ghost/helm/ghost/Chart.yaml
@@ -2,9 +2,10 @@ apiVersion: v2
 name: ghost
 description: A Helm chart for Kubernetes
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "5.49.2"
 dependencies:
 - name: mysql
   version: 0.6.6
   repository: https://pluralsh.github.io/module-library
+  condition: mysql.enabled

--- a/ghost/helm/ghost/values.yaml
+++ b/ghost/helm/ghost/values.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 
 mysql:
+  enabled: true
   rootPassword: replace
   appUser: ghost
   appPassword: replace


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you with us! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ]  No images hosted from dockerhub
- [ ]  Are dashboards present to understand the health of the application.  There **must** be at least 1 of these
    - [ ]  all databases should have dashboards
    - [ ]  ideally also have at least cpu/mem utilization dashboards for webserver tier of the app
    - [ ]  you can use `plural from-grafana` to convert a grafana dashboard found via google to our CRD
- [ ]  Are scaling runbooks present
    - [ ]  all databases **must** have scaling runbooks
    - [ ]  you can use the charts in `pluralsh/module-library` to accelerate this
- [ ]  do you need to add config overlays?
    - [ ]  inputing secrets
    - [ ]  configuring autoscaling
- [ ]  If there’s a web-facing component to the app, we need to support OIDC authentication and setting up private networks if no authentication option is viable
- [ ]  All major clouds must be supported
    - [ ]  Azure
    - [ ]  AWS
    - [ ]  GCP