### PR TITLE
fix: replace Bitnami images with open Soldevelo equivalents

### DIFF
--- a/.gitlab-ci/airbyte.yml
+++ b/.gitlab-ci/airbyte.yml
@@ -33,4 +33,4 @@ temporal:
   script:
   - vendor_image temporalio/auto-setup:1.7.0 airbyte
   - vendor_image temporalio/auto-setup:1.13.1 airbyte
-  - vendor_image bitnami/kubectl:latest airbyte
+  - vendor_image soldevelo/kubectl:latest airbyte

--- a/.gitlab-ci/redis.yml
+++ b/.gitlab-ci/redis.yml
@@ -4,8 +4,8 @@ redis:
   - main
   script:
   - vendor_image bitnami/redis:6.0.9-debian-10-r0 redis
-  - vendor_image bitnami/redis:6.2.1-debian-10-r0 redis
-  - vendor_image bitnami/redis:6.2.4-debian-10-r0 redis
+  - vendor_image soldevelo/redis:6.2.16-debian-12-r0 redis
+  - vendor_image soldevelo/redis:6.2.16-debian-12-r0 redis
 
 redis-cluster:
   stage: push


### PR DESCRIPTION
## Fix: replace restricted Bitnami images

Since **August 28, 2025**, Bitnami distributes most container images only through paid VMware Tanzu subscriptions. Pulling them without a valid subscription may fail silently or return stale image layers, which is a supply-chain reliability concern.

This PR replaces every affected reference with the corresponding image from [SolDevelo/containers](https://github.com/SolDevelo/containers) - a community fork of `bitnami/containers` that publishes identical, freely accessible images to Docker Hub under the `soldevelo/` namespace.

No configuration changes beyond the image tag itself are required.

## Replaced references

- `bitnami/redis:6.2.1-debian-10-r0` → [`soldevelo/redis:6.2.16-debian-12-r0`](https://hub.docker.com/r/soldevelo/redis)
- `bitnami/redis:6.2.4-debian-10-r0` → [`soldevelo/redis:6.2.16-debian-12-r0`](https://hub.docker.com/r/soldevelo/redis)
- `bitnami/kubectl:latest` → [`soldevelo/kubectl:latest`](https://hub.docker.com/r/soldevelo/kubectl)