### PR TITLE
fix(lightdash/aws): migrate deprecated kubernetes namespace and service account resources to v1

### DIFF
--- a/lightdash/terraform/aws/main.tf
+++ b/lightdash/terraform/aws/main.tf
@@ -1,9 +1,9 @@
-resource "kubernetes_namespace" "lightdash" {
+resource "kubernetes_namespace_v1" "lightdash" {
   metadata {
     name = var.namespace
     labels = {
       "app.kubernetes.io/managed-by" = "plural"
-      "app.plural.sh/name" = "lightdash"
+      "app.plural.sh/name"           = "lightdash"
 
       "platform.plural.sh/sync-target" = "pg"
 
@@ -16,7 +16,7 @@ data "aws_iam_role" "postgres" {
   name = "${var.cluster_name}-postgres"
 }
 
-resource "kubernetes_service_account" "postgres" {
+resource "kubernetes_service_account_v1" "postgres" {
   metadata {
     name      = "postgres-pod"
     namespace = var.namespace
@@ -27,6 +27,6 @@ resource "kubernetes_service_account" "postgres" {
   }
 
   depends_on = [
-    kubernetes_namespace.lightdash
+    kubernetes_namespace_v1.lightdash
   ]
 }


### PR DESCRIPTION
Closes #930.

This switches the Lightdash AWS Terraform module from the deprecated Kubernetes resources to the v1 resources and updates the `depends_on` reference to match.

I validated the module in an isolated copy with:

- `terraform fmt -check main.tf`
- `terraform init -backend=false`
- `terraform validate`

I also checked the upgrade path against existing state in a local kind/Terraform lab. A straight rename is not enough here: Terraform plans to destroy and recreate these resources, and `moved` is not supported for this type change. The safe path I found was a one-time root-level migration using `removed { destroy = false }` and `import`. After importing state into the `_v1` addresses, the next `terraform plan` is clean.

The checked-in `terraform.tfvars` is only a template, so the validation run used temporary concrete values for `namespace` and `cluster_name`.

I did not run a full `plural link/build/deploy` flow from this environment.

### Existing-state migration note
Because Terraform does not support `moved` across these resource types, existing installs need a one-time root-level migration during upgrade. The pattern I tested was:

```hcl
removed {
  from = module.<your-module>.kubernetes_service_account.postgres
  lifecycle {
    destroy = false
  }
}

removed {
  from = module.<your-module>.kubernetes_namespace.lightdash
  lifecycle {
    destroy = false
  }
}

import {
  to = module.<your-module>.kubernetes_namespace_v1.lightdash
  id = "<namespace>"
}

import {
  to = module.<your-module>.kubernetes_service_account_v1.postgres
  id = "<namespace>/postgres-pod"
}
```

After that apply, the next `terraform plan` should be clean.